### PR TITLE
feat: Add USDT-M Futures support with MarketType enum (v6.0.0)

### DIFF
--- a/docs/plans/2026-02-05-futures-support-design.md
+++ b/docs/plans/2026-02-05-futures-support-design.md
@@ -1,0 +1,292 @@
+# Futures Support Design
+
+**Date:** 2026-02-05
+**Status:** Draft
+**Related Issue:** https://github.com/EonLabs-Spartan/alpha-forge/issues/128
+
+## Summary
+
+Add support for Binance USDT-M Futures to gapless-crypto-data, enabling 10-100x faster data loading for futures backtesting in Alpha Forge.
+
+## Goals
+
+- Support USDT-M futures from Binance Vision (`futures` as alias for `um`)
+- Require explicit market type selection (no default - breaking change)
+- Minimal API surface change (single new required parameter)
+- Reuse existing gap detection/filling infrastructure
+
+## Non-Goals
+
+- Coin-M (CM) futures support (can add later if needed)
+- Symbol validation per market type (let Binance be source of truth)
+- Maintaining symbol lists (deprecated `get_supported_symbols()`)
+- Supporting other exchanges (Binance only)
+
+---
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| API parameter | `market_type` (required, no default) | Forces explicit choice, clearer intent |
+| Market type values | `"spot"`, `"futures"` | Simple; `futures` = USDT-M (most common) |
+| URL construction | Enum with `base_path` property | Type-safe, extensible |
+| Filename convention | `binance_{market_type}_SYMBOL-...` | Clear, consistent |
+| Symbol validation | None | Symbol lists change frequently |
+| fill_gaps() behavior | Auto-detect from filename | Convenient, with explicit override |
+| get_supported_symbols() | Deprecated | No validation means no need for lists |
+| Breaking change handling | Major version bump to 6.0.0 | Clear migration path |
+
+---
+
+## Implementation
+
+### 1. Core Data Types
+
+**New file: `src/gapless_crypto_data/market_types.py`**
+
+```python
+from enum import Enum
+
+class MarketType(str, Enum):
+    """Binance market types supported by gapless-crypto-data."""
+
+    SPOT = "spot"
+    FUTURES = "futures"  # USDT-M perpetual futures (alias for "um")
+
+    @property
+    def base_path(self) -> str:
+        """Return the Binance Vision URL path segment."""
+        if self == MarketType.SPOT:
+            return "spot"
+        return "futures/um"  # USDT-M futures
+
+    @property
+    def filename_prefix(self) -> str:
+        """Return prefix for output filenames."""
+        return f"binance_{self.value}_"
+```
+
+### 2. HybridUrlGenerator Changes
+
+**File: `src/gapless_crypto_data/collectors/hybrid_url_generator.py`**
+
+```python
+def __init__(
+    self,
+    daily_lookback_days: int = 30,
+    market_type: MarketType,  # REQUIRED - no default
+    max_concurrent_per_batch: int = 13,
+):
+    self.daily_lookback_days = daily_lookback_days
+    self.market_type = market_type
+    self.max_concurrent_per_batch = max_concurrent_per_batch
+
+    # Compute base_url from market_type
+    self.base_url = f"https://data.binance.vision/data/{market_type.base_path}"
+
+    self.cutoff_date = datetime.now() - timedelta(days=daily_lookback_days)
+```
+
+URL generation methods remain unchanged - they already use `self.base_url`.
+
+### 3. BinancePublicDataCollector Changes
+
+**File: `src/gapless_crypto_data/collectors/binance_public_data_collector.py`**
+
+```python
+def __init__(
+    self,
+    symbol: str = "BTCUSDT",
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    market_type: MarketType,  # REQUIRED - no default
+    ...
+):
+    self.symbol = symbol
+    self.market_type = market_type
+
+    # Compute base_url from market_type
+    self.base_url = f"https://data.binance.vision/data/{market_type.base_path}/monthly/klines"
+```
+
+**Metadata generation:** `metadata["market_type"] = self.market_type.value`
+
+**Filename generation:** `f"{self.market_type.filename_prefix}{self.symbol}-{timeframe}_..."`
+
+### 4. API Layer Changes
+
+**File: `src/gapless_crypto_data/api.py`**
+
+```python
+def fetch_data(
+    symbol: str,
+    market_type: str,  # REQUIRED - no default
+    timeframe: str = "1h",
+    limit: Optional[int] = None,
+    start: Optional[str] = None,
+    end: Optional[str] = None,
+    output_dir: Optional[str] = None,
+    auto_fill_gaps: bool = True,
+    ...
+) -> pd.DataFrame:
+    """
+    Fetch OHLCV data from Binance.
+
+    Args:
+        symbol: Trading pair (e.g., "BTCUSDT")
+        market_type: Market type - "spot" or "futures" (USDT-M). REQUIRED.
+        timeframe: Candlestick interval (default: "1h")
+
+    Raises:
+        TypeError: If market_type is not provided
+        ValueError: If market_type is not "spot" or "futures"
+    """
+    if market_type is None:
+        raise TypeError("market_type is required. Use 'spot' or 'futures'.")
+
+    market_type_enum = MarketType(market_type)
+
+    collector = BinancePublicDataCollector(
+        symbol=symbol,
+        market_type=market_type_enum,
+        ...
+    )
+```
+
+Same pattern for `download()`.
+
+### 5. Gap Filling Changes
+
+```python
+def _detect_market_type_from_filename(filename: str) -> Optional[MarketType]:
+    """Parse market type from filename pattern: binance_{market_type}_..."""
+    for market_type in MarketType:
+        if f"binance_{market_type.value}_" in filename:
+            return market_type
+    return None
+
+def fill_gaps(
+    directory: Optional[str] = None,
+    symbols: Optional[List[str]] = None,
+    market_type: Optional[str] = None,  # Optional - auto-detects from filename
+) -> dict:
+    # Auto-detect from filename, use override if provided
+    # Raises error if cannot detect and no override provided
+```
+
+---
+
+## Breaking Changes & Migration
+
+### What Breaks
+
+```python
+# OLD (v5.x) - worked with implicit spot
+fetch_data(symbol="BTCUSDT", timeframe="1h")
+
+# NEW (v6.0) - requires explicit market_type
+fetch_data(symbol="BTCUSDT", market_type="spot", timeframe="1h")
+```
+
+### Migration Path
+
+1. **Version bump**: `5.x.x` → `6.0.0`
+2. **Clear error message**: `TypeError: market_type is required. Use 'spot' or 'futures'.`
+3. **Alpha Forge updates**: Update all plugins using gapless-crypto-data to pass explicit `market_type="spot"`
+
+### Alpha Forge Plugins to Update
+
+| Plugin | Change |
+|--------|--------|
+| `pypi_gapless_crypto_data_binance_spot` | Add `market_type="spot"` to fetch_data call |
+
+---
+
+## Test Plan
+
+**New tests:**
+- `test_market_types.py` - MarketType enum behavior
+- URL generation tests for spot/futures paths
+- Filename prefix tests
+- Test that missing market_type raises TypeError
+
+**Updated tests:**
+- Add `market_type` parameter to ALL existing collector tests
+- Test `fetch_data(market_type="futures")`
+- Test auto-detection from filename in gap filler
+
+**Integration test:**
+```python
+@pytest.mark.integration
+def test_fetch_futures_data():
+    df = fetch_data(
+        symbol="BTCUSDT",
+        market_type="futures",
+        timeframe="1d",
+        start="2024-01-01",
+        end="2024-01-07"
+    )
+    assert len(df) > 0
+```
+
+---
+
+## Files Changed
+
+| File | Change Type | Estimated Lines |
+|------|-------------|-----------------|
+| `market_types.py` | New | ~20 |
+| `hybrid_url_generator.py` | Modify | ~15 |
+| `binance_public_data_collector.py` | Modify | ~30 |
+| `api.py` | Modify | ~50 |
+| `__init__.py` | Modify | ~10 |
+| Tests | New + Modify | ~150 |
+| **Total** | | **~275** |
+
+---
+
+## Usage Examples
+
+**Fetch USDT-M Futures:**
+```python
+from gapless_crypto_data import fetch_data
+
+df = fetch_data(
+    symbol="BTCUSDT",
+    market_type="futures",
+    timeframe="1h",
+    start="2024-01-01",
+    end="2024-12-31"
+)
+```
+
+**Fetch Spot data:**
+```python
+df = fetch_data(
+    symbol="BTCUSDT",
+    market_type="spot",
+    timeframe="1h",
+    start="2024-01-01",
+    end="2024-12-31"
+)
+```
+
+---
+
+## Rollout Plan
+
+1. Implement changes in feature branch of gapless-crypto-data
+2. Run full test suite including integration tests
+3. Create PR to gapless-crypto-data
+4. After merge, release version **6.0.0** (breaking change)
+5. Update Alpha Forge:
+   - Update `pypi_gapless_crypto_data_binance_spot` to pass `market_type="spot"`
+   - Create new plugin `pypi_gapless_crypto_data_binance_futures`
+   - Update gapless-crypto-data dependency to `>=6.0.0`
+
+---
+
+## Open Questions
+
+None - all design decisions resolved.

--- a/docs/plans/2026-02-05-futures-support-implementation.md
+++ b/docs/plans/2026-02-05-futures-support-implementation.md
@@ -1,0 +1,916 @@
+# Futures Support Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add required `market_type` parameter to gapless-crypto-data, supporting "spot" and "futures" (USDT-M) markets.
+
+**Architecture:** Add `MarketType` enum, thread it through URL generator → collector → API layer. Breaking change requires v6.0.0.
+
+**Tech Stack:** Python 3.9+, pytest, pandas
+
+---
+
+## Task 1: Create MarketType Enum
+
+**Files:**
+- Create: `src/gapless_crypto_data/market_types.py`
+- Test: `tests/test_market_types.py`
+
+**Step 1: Write the failing test**
+
+Create `tests/test_market_types.py`:
+
+```python
+"""Tests for MarketType enum."""
+
+import pytest
+
+from gapless_crypto_data.market_types import MarketType
+
+
+class TestMarketType:
+    """Tests for MarketType enum and properties."""
+
+    def test_spot_value(self):
+        """Spot market type has correct string value."""
+        assert MarketType.SPOT.value == "spot"
+
+    def test_futures_value(self):
+        """Futures market type has correct string value."""
+        assert MarketType.FUTURES.value == "futures"
+
+    def test_spot_base_path(self):
+        """Spot market returns 'spot' base path."""
+        assert MarketType.SPOT.base_path == "spot"
+
+    def test_futures_base_path(self):
+        """Futures market returns 'futures/um' base path."""
+        assert MarketType.FUTURES.base_path == "futures/um"
+
+    def test_spot_filename_prefix(self):
+        """Spot market has correct filename prefix."""
+        assert MarketType.SPOT.filename_prefix == "binance_spot_"
+
+    def test_futures_filename_prefix(self):
+        """Futures market has correct filename prefix."""
+        assert MarketType.FUTURES.filename_prefix == "binance_futures_"
+
+    def test_string_conversion_spot(self):
+        """Can create MarketType from 'spot' string."""
+        assert MarketType("spot") == MarketType.SPOT
+
+    def test_string_conversion_futures(self):
+        """Can create MarketType from 'futures' string."""
+        assert MarketType("futures") == MarketType.FUTURES
+
+    def test_invalid_market_type_raises(self):
+        """Invalid market type raises ValueError."""
+        with pytest.raises(ValueError):
+            MarketType("invalid")
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && uv run pytest tests/test_market_types.py -v
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'gapless_crypto_data.market_types'`
+
+**Step 3: Write minimal implementation**
+
+Create `src/gapless_crypto_data/market_types.py`:
+
+```python
+"""Market type definitions for Binance data sources."""
+
+from enum import Enum
+
+
+class MarketType(str, Enum):
+    """Binance market types supported by gapless-crypto-data.
+
+    Attributes:
+        SPOT: Binance spot market data
+        FUTURES: Binance USDT-M perpetual futures data
+
+    Examples:
+        >>> MarketType.SPOT.base_path
+        'spot'
+        >>> MarketType.FUTURES.base_path
+        'futures/um'
+        >>> MarketType("futures") == MarketType.FUTURES
+        True
+    """
+
+    SPOT = "spot"
+    FUTURES = "futures"
+
+    @property
+    def base_path(self) -> str:
+        """Return the Binance Vision URL path segment.
+
+        Returns:
+            URL path segment for this market type.
+
+        Examples:
+            >>> MarketType.SPOT.base_path
+            'spot'
+            >>> MarketType.FUTURES.base_path
+            'futures/um'
+        """
+        if self == MarketType.SPOT:
+            return "spot"
+        return "futures/um"
+
+    @property
+    def filename_prefix(self) -> str:
+        """Return prefix for output filenames.
+
+        Returns:
+            Filename prefix string.
+
+        Examples:
+            >>> MarketType.SPOT.filename_prefix
+            'binance_spot_'
+            >>> MarketType.FUTURES.filename_prefix
+            'binance_futures_'
+        """
+        return f"binance_{self.value}_"
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && uv run pytest tests/test_market_types.py -v
+```
+
+Expected: All 9 tests PASS
+
+**Step 5: Commit**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && git add src/gapless_crypto_data/market_types.py tests/test_market_types.py && git commit -m "feat: add MarketType enum with spot and futures support"
+```
+
+---
+
+## Task 2: Update HybridUrlGenerator
+
+**Files:**
+- Modify: `src/gapless_crypto_data/collectors/hybrid_url_generator.py`
+- Test: `tests/test_hybrid_url_generator.py` (create new)
+
+**Step 1: Write the failing test**
+
+Create `tests/test_hybrid_url_generator.py`:
+
+```python
+"""Tests for HybridUrlGenerator market type support."""
+
+import pytest
+from datetime import datetime
+
+from gapless_crypto_data.collectors.hybrid_url_generator import HybridUrlGenerator
+from gapless_crypto_data.market_types import MarketType
+
+
+class TestHybridUrlGeneratorMarketType:
+    """Tests for market_type parameter in HybridUrlGenerator."""
+
+    def test_spot_base_url(self):
+        """Spot market type generates correct base URL."""
+        generator = HybridUrlGenerator(market_type=MarketType.SPOT)
+        assert generator.base_url == "https://data.binance.vision/data/spot"
+
+    def test_futures_base_url(self):
+        """Futures market type generates correct base URL."""
+        generator = HybridUrlGenerator(market_type=MarketType.FUTURES)
+        assert generator.base_url == "https://data.binance.vision/data/futures/um"
+
+    def test_market_type_required(self):
+        """market_type parameter is required (no default)."""
+        with pytest.raises(TypeError):
+            HybridUrlGenerator()  # Missing required market_type
+
+    def test_spot_monthly_url_generation(self):
+        """Spot market generates correct monthly klines URL."""
+        generator = HybridUrlGenerator(market_type=MarketType.SPOT)
+        tasks = generator.generate_download_tasks(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2023, 1, 1),
+            end_date=datetime(2023, 1, 31),
+        )
+        # Check first task URL contains spot path
+        assert "/spot/monthly/klines/BTCUSDT/1h/" in tasks[0].url
+
+    def test_futures_monthly_url_generation(self):
+        """Futures market generates correct monthly klines URL."""
+        generator = HybridUrlGenerator(market_type=MarketType.FUTURES)
+        tasks = generator.generate_download_tasks(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2023, 1, 1),
+            end_date=datetime(2023, 1, 31),
+        )
+        # Check first task URL contains futures/um path
+        assert "/futures/um/monthly/klines/BTCUSDT/1h/" in tasks[0].url
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && uv run pytest tests/test_hybrid_url_generator.py -v
+```
+
+Expected: FAIL - tests fail because market_type parameter doesn't exist yet
+
+**Step 3: Write minimal implementation**
+
+Modify `src/gapless_crypto_data/collectors/hybrid_url_generator.py`:
+
+At the top, add import:
+```python
+from gapless_crypto_data.market_types import MarketType
+```
+
+Modify `__init__` method (around line 84-100):
+
+```python
+def __init__(
+    self,
+    market_type: MarketType,  # REQUIRED - no default
+    daily_lookback_days: int = 30,
+    max_concurrent_per_batch: int = 13,
+):
+    """
+    Initialize hybrid URL generator with configuration.
+
+    Args:
+        market_type: Market type (MarketType.SPOT or MarketType.FUTURES). REQUIRED.
+        daily_lookback_days: Number of days to use daily files for recent data
+        max_concurrent_per_batch: Maximum concurrent downloads per batch (13 for ZIP files)
+    """
+    self.market_type = market_type
+    self.daily_lookback_days = daily_lookback_days
+    self.max_concurrent_per_batch = max_concurrent_per_batch
+
+    # Compute base_url from market_type
+    self.base_url = f"https://data.binance.vision/data/{market_type.base_path}"
+
+    # Calculate cutoff date for monthly vs daily strategy
+    self.cutoff_date = datetime.now() - timedelta(days=daily_lookback_days)
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && uv run pytest tests/test_hybrid_url_generator.py -v
+```
+
+Expected: All 5 tests PASS
+
+**Step 5: Commit**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && git add src/gapless_crypto_data/collectors/hybrid_url_generator.py tests/test_hybrid_url_generator.py && git commit -m "feat: add market_type parameter to HybridUrlGenerator"
+```
+
+---
+
+## Task 3: Update BinancePublicDataCollector
+
+**Files:**
+- Modify: `src/gapless_crypto_data/collectors/binance_public_data_collector.py`
+- Test: `tests/test_binance_collector_market_type.py` (create new)
+
+**Step 1: Write the failing test**
+
+Create `tests/test_binance_collector_market_type.py`:
+
+```python
+"""Tests for BinancePublicDataCollector market type support."""
+
+import pytest
+
+from gapless_crypto_data.collectors.binance_public_data_collector import (
+    BinancePublicDataCollector,
+)
+from gapless_crypto_data.market_types import MarketType
+
+
+class TestBinanceCollectorMarketType:
+    """Tests for market_type parameter in BinancePublicDataCollector."""
+
+    def test_spot_base_url(self):
+        """Spot market type sets correct base URL."""
+        collector = BinancePublicDataCollector(
+            symbol="BTCUSDT",
+            market_type=MarketType.SPOT,
+        )
+        assert "data/spot/monthly/klines" in collector.base_url
+
+    def test_futures_base_url(self):
+        """Futures market type sets correct base URL."""
+        collector = BinancePublicDataCollector(
+            symbol="BTCUSDT",
+            market_type=MarketType.FUTURES,
+        )
+        assert "data/futures/um/monthly/klines" in collector.base_url
+
+    def test_market_type_required(self):
+        """market_type parameter is required (no default)."""
+        with pytest.raises(TypeError):
+            BinancePublicDataCollector(symbol="BTCUSDT")  # Missing market_type
+
+    def test_market_type_stored(self):
+        """market_type is stored on collector instance."""
+        collector = BinancePublicDataCollector(
+            symbol="BTCUSDT",
+            market_type=MarketType.FUTURES,
+        )
+        assert collector.market_type == MarketType.FUTURES
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && uv run pytest tests/test_binance_collector_market_type.py -v
+```
+
+Expected: FAIL - tests fail because market_type parameter doesn't exist yet
+
+**Step 3: Write minimal implementation**
+
+Modify `src/gapless_crypto_data/collectors/binance_public_data_collector.py`:
+
+At the top, add import:
+```python
+from gapless_crypto_data.market_types import MarketType
+```
+
+Find the `__init__` method and modify its signature and body. The key changes:
+
+1. Add `market_type: MarketType` as required parameter (no default)
+2. Store `self.market_type = market_type`
+3. Update `self.base_url` to use market_type:
+   ```python
+   self.base_url = f"https://data.binance.vision/data/{market_type.base_path}/monthly/klines"
+   ```
+
+Also update any places where `HybridUrlGenerator` is instantiated to pass `market_type`.
+
+**Step 4: Run test to verify it passes**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && uv run pytest tests/test_binance_collector_market_type.py -v
+```
+
+Expected: All 4 tests PASS
+
+**Step 5: Commit**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && git add src/gapless_crypto_data/collectors/binance_public_data_collector.py tests/test_binance_collector_market_type.py && git commit -m "feat: add market_type parameter to BinancePublicDataCollector"
+```
+
+---
+
+## Task 4: Update Collector Filename Generation
+
+**Files:**
+- Modify: `src/gapless_crypto_data/collectors/binance_public_data_collector.py`
+- Test: `tests/test_binance_collector_market_type.py` (add tests)
+
+**Step 1: Write the failing test**
+
+Add to `tests/test_binance_collector_market_type.py`:
+
+```python
+class TestBinanceCollectorFilenames:
+    """Tests for market-type-aware filename generation."""
+
+    def test_spot_filename_prefix(self):
+        """Spot files have 'binance_spot_' prefix."""
+        collector = BinancePublicDataCollector(
+            symbol="BTCUSDT",
+            market_type=MarketType.SPOT,
+        )
+        # The filename generation uses market_type.filename_prefix
+        expected_prefix = "binance_spot_"
+        assert collector.market_type.filename_prefix == expected_prefix
+
+    def test_futures_filename_prefix(self):
+        """Futures files have 'binance_futures_' prefix."""
+        collector = BinancePublicDataCollector(
+            symbol="BTCUSDT",
+            market_type=MarketType.FUTURES,
+        )
+        expected_prefix = "binance_futures_"
+        assert collector.market_type.filename_prefix == expected_prefix
+```
+
+**Step 2: Run test to verify it passes**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && uv run pytest tests/test_binance_collector_market_type.py::TestBinanceCollectorFilenames -v
+```
+
+Expected: PASS (this tests the enum property, which already works)
+
+**Step 3: Update filename generation in collector**
+
+Find the filename generation code in `binance_public_data_collector.py` (search for `binance_spot_` or the output filename pattern) and update it to use:
+
+```python
+f"{self.market_type.filename_prefix}{self.symbol}-{timeframe}_..."
+```
+
+**Step 4: Verify existing tests still pass**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && uv run pytest tests/test_binance_collector_market_type.py -v
+```
+
+Expected: All tests PASS
+
+**Step 5: Commit**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && git add src/gapless_crypto_data/collectors/binance_public_data_collector.py tests/test_binance_collector_market_type.py && git commit -m "feat: use market_type for filename prefix in collector"
+```
+
+---
+
+## Task 5: Update API Layer - fetch_data()
+
+**Files:**
+- Modify: `src/gapless_crypto_data/api.py`
+- Test: `tests/test_api_market_type.py` (create new)
+
+**Step 1: Write the failing test**
+
+Create `tests/test_api_market_type.py`:
+
+```python
+"""Tests for API market_type parameter."""
+
+import pytest
+
+from gapless_crypto_data import fetch_data
+from gapless_crypto_data.market_types import MarketType
+
+
+class TestFetchDataMarketType:
+    """Tests for market_type parameter in fetch_data()."""
+
+    def test_market_type_required(self):
+        """fetch_data raises TypeError when market_type is missing."""
+        with pytest.raises(TypeError) as exc_info:
+            fetch_data(symbol="BTCUSDT", timeframe="1h")
+        assert "market_type is required" in str(exc_info.value)
+
+    def test_market_type_spot_accepted(self):
+        """fetch_data accepts market_type='spot'."""
+        # This will fail at data fetch, but should not raise on validation
+        # We mock or use a very short date range to avoid actual download
+        try:
+            fetch_data(
+                symbol="BTCUSDT",
+                market_type="spot",
+                timeframe="1d",
+                start="2024-01-01",
+                end="2024-01-01",
+            )
+        except Exception as e:
+            # Should not be a market_type validation error
+            assert "market_type" not in str(e).lower()
+
+    def test_market_type_futures_accepted(self):
+        """fetch_data accepts market_type='futures'."""
+        try:
+            fetch_data(
+                symbol="BTCUSDT",
+                market_type="futures",
+                timeframe="1d",
+                start="2024-01-01",
+                end="2024-01-01",
+            )
+        except Exception as e:
+            # Should not be a market_type validation error
+            assert "market_type" not in str(e).lower()
+
+    def test_invalid_market_type_raises(self):
+        """fetch_data raises ValueError for invalid market_type."""
+        with pytest.raises(ValueError):
+            fetch_data(
+                symbol="BTCUSDT",
+                market_type="invalid",
+                timeframe="1h",
+            )
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && uv run pytest tests/test_api_market_type.py -v
+```
+
+Expected: FAIL - market_type parameter doesn't exist yet
+
+**Step 3: Write minimal implementation**
+
+Modify `src/gapless_crypto_data/api.py`:
+
+1. Add import at top:
+```python
+from .market_types import MarketType
+```
+
+2. Update `fetch_data()` signature (around line 357):
+```python
+def fetch_data(
+    symbol: Union[str, SupportedSymbol],
+    market_type: str,  # REQUIRED - no default
+    timeframe: Optional[Union[str, SupportedTimeframe]] = None,
+    limit: Optional[int] = None,
+    start: Optional[str] = None,
+    end: Optional[str] = None,
+    output_dir: Optional[Union[str, Path]] = None,
+    index_type: Optional[Literal["datetime", "range", "auto"]] = None,
+    auto_fill_gaps: bool = True,
+    *,
+    interval: Optional[Union[str, SupportedTimeframe]] = None,
+) -> pd.DataFrame:
+```
+
+3. Add validation at start of function body:
+```python
+    # Validate market_type (required parameter)
+    if market_type is None:
+        raise TypeError(
+            "market_type is required. Use 'spot' or 'futures'."
+        )
+
+    # Convert string to enum (raises ValueError if invalid)
+    market_type_enum = MarketType(market_type)
+```
+
+4. Update collector instantiation to pass market_type:
+```python
+    collector = BinancePublicDataCollector(
+        symbol=symbol,
+        market_type=market_type_enum,
+        start_date=start,
+        end_date=end,
+        output_dir=str(output_dir) if output_dir else None,
+    )
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && uv run pytest tests/test_api_market_type.py -v
+```
+
+Expected: All 4 tests PASS
+
+**Step 5: Commit**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && git add src/gapless_crypto_data/api.py tests/test_api_market_type.py && git commit -m "feat: add required market_type parameter to fetch_data()"
+```
+
+---
+
+## Task 6: Update API Layer - download()
+
+**Files:**
+- Modify: `src/gapless_crypto_data/api.py`
+- Test: `tests/test_api_market_type.py` (add tests)
+
+**Step 1: Write the failing test**
+
+Add to `tests/test_api_market_type.py`:
+
+```python
+from gapless_crypto_data import download
+
+
+class TestDownloadMarketType:
+    """Tests for market_type parameter in download()."""
+
+    def test_market_type_required(self):
+        """download raises TypeError when market_type is missing."""
+        with pytest.raises(TypeError) as exc_info:
+            download(symbol="BTCUSDT", timeframe="1h")
+        assert "market_type is required" in str(exc_info.value)
+
+    def test_market_type_passed_to_fetch_data(self):
+        """download passes market_type to fetch_data."""
+        # This tests that download() correctly passes market_type through
+        try:
+            download(
+                symbol="BTCUSDT",
+                market_type="futures",
+                timeframe="1d",
+                start="2024-01-01",
+                end="2024-01-01",
+            )
+        except Exception as e:
+            # Should not be a market_type validation error
+            assert "market_type" not in str(e).lower()
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && uv run pytest tests/test_api_market_type.py::TestDownloadMarketType -v
+```
+
+Expected: FAIL - download() doesn't have market_type yet
+
+**Step 3: Write minimal implementation**
+
+Find the `download()` function in `api.py` and update it similarly to `fetch_data()`:
+
+1. Add `market_type: str` as required parameter
+2. Pass it through to `fetch_data()`
+
+**Step 4: Run test to verify it passes**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && uv run pytest tests/test_api_market_type.py -v
+```
+
+Expected: All tests PASS
+
+**Step 5: Commit**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && git add src/gapless_crypto_data/api.py tests/test_api_market_type.py && git commit -m "feat: add required market_type parameter to download()"
+```
+
+---
+
+## Task 7: Update Exports and Deprecate get_supported_symbols
+
+**Files:**
+- Modify: `src/gapless_crypto_data/__init__.py`
+- Modify: `src/gapless_crypto_data/api.py`
+
+**Step 1: Update __init__.py exports**
+
+Add `MarketType` to the exports in `__init__.py`:
+
+```python
+from .market_types import MarketType
+
+__all__ = [
+    "fetch_data",
+    "download",
+    "fill_gaps",
+    "get_supported_timeframes",
+    "get_supported_symbols",  # Deprecated
+    "MarketType",
+]
+```
+
+**Step 2: Deprecate get_supported_symbols**
+
+In `api.py`, update `get_supported_symbols()`:
+
+```python
+def get_supported_symbols() -> List[str]:
+    """Get list of supported trading pairs.
+
+    .. deprecated::
+        This function is deprecated and will be removed in v7.0.0.
+        Symbol validation is no longer performed. Use any valid Binance symbol.
+
+    Returns:
+        Empty list (function deprecated)
+    """
+    import warnings
+
+    warnings.warn(
+        "get_supported_symbols() is deprecated and will be removed in v7.0.0. "
+        "Symbol validation is no longer performed. Use any valid Binance symbol.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return []
+```
+
+**Step 3: Run tests**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && uv run pytest tests/test_market_types.py tests/test_api_market_type.py -v
+```
+
+Expected: All tests PASS
+
+**Step 4: Commit**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && git add src/gapless_crypto_data/__init__.py src/gapless_crypto_data/api.py && git commit -m "feat: export MarketType, deprecate get_supported_symbols()"
+```
+
+---
+
+## Task 8: Fix Existing Tests
+
+**Files:**
+- Modify: Multiple test files that call API without market_type
+
+**Step 1: Find all test files that need updating**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && grep -r "fetch_data\|download\|BinancePublicDataCollector" tests/ --include="*.py" | grep -v market_type | head -20
+```
+
+**Step 2: Update each test file**
+
+For each test that instantiates `BinancePublicDataCollector` or calls `fetch_data`/`download`, add `market_type=MarketType.SPOT` or `market_type="spot"`.
+
+Common patterns to update:
+- `BinancePublicDataCollector(symbol="BTCUSDT")` → `BinancePublicDataCollector(symbol="BTCUSDT", market_type=MarketType.SPOT)`
+- `fetch_data("BTCUSDT", "1h")` → `fetch_data("BTCUSDT", market_type="spot", timeframe="1h")`
+
+**Step 3: Run full test suite**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && uv run pytest tests/ -v --ignore=tests/test_integration.py
+```
+
+Expected: All tests PASS
+
+**Step 4: Commit**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && git add tests/ && git commit -m "fix: update existing tests for required market_type parameter"
+```
+
+---
+
+## Task 9: Integration Test
+
+**Files:**
+- Create: `tests/test_futures_integration.py`
+
+**Step 1: Write integration test**
+
+Create `tests/test_futures_integration.py`:
+
+```python
+"""Integration tests for futures data fetching."""
+
+import pytest
+
+from gapless_crypto_data import fetch_data
+
+
+@pytest.mark.integration
+class TestFuturesIntegration:
+    """Integration tests for USDT-M futures data."""
+
+    def test_fetch_futures_btcusdt_1d(self):
+        """Fetch 1 day of BTCUSDT futures data."""
+        df = fetch_data(
+            symbol="BTCUSDT",
+            market_type="futures",
+            timeframe="1d",
+            start="2024-01-01",
+            end="2024-01-07",
+        )
+
+        assert len(df) > 0
+        assert "close" in df.columns
+        assert "volume" in df.columns
+
+    def test_fetch_spot_btcusdt_1d(self):
+        """Fetch 1 day of BTCUSDT spot data."""
+        df = fetch_data(
+            symbol="BTCUSDT",
+            market_type="spot",
+            timeframe="1d",
+            start="2024-01-01",
+            end="2024-01-07",
+        )
+
+        assert len(df) > 0
+        assert "close" in df.columns
+```
+
+**Step 2: Run integration test**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && uv run pytest tests/test_futures_integration.py -v -m integration
+```
+
+Expected: All tests PASS (requires network)
+
+**Step 3: Commit**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && git add tests/test_futures_integration.py && git commit -m "test: add futures integration tests"
+```
+
+---
+
+## Task 10: Update Version and Documentation
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify: `src/gapless_crypto_data/__init__.py` (docstring)
+
+**Step 1: Bump version to 6.0.0**
+
+In `pyproject.toml`, update version:
+```toml
+version = "6.0.0"
+```
+
+**Step 2: Update module docstring**
+
+In `src/gapless_crypto_data/__init__.py`, update the docstring to reflect new API:
+
+```python
+"""
+gapless-crypto-data: Zero-gaps cryptocurrency OHLCV data from Binance.
+
+Supports both Spot and USDT-M Futures markets.
+
+Examples:
+    # Fetch spot data
+    import gapless_crypto_data as gcd
+    df = gcd.fetch_data("BTCUSDT", market_type="spot", timeframe="1h")
+
+    # Fetch futures data
+    df = gcd.fetch_data("BTCUSDT", market_type="futures", timeframe="1h")
+
+Breaking change in v6.0.0: market_type parameter is now required.
+"""
+```
+
+**Step 3: Commit**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && git add pyproject.toml src/gapless_crypto_data/__init__.py && git commit -m "chore: bump version to 6.0.0, update documentation"
+```
+
+---
+
+## Task 11: Final Validation
+
+**Step 1: Run full test suite**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && uv run pytest tests/ -v
+```
+
+Expected: All tests PASS
+
+**Step 2: Run integration tests**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && uv run pytest tests/ -v -m integration
+```
+
+Expected: Integration tests PASS
+
+**Step 3: Test manual usage**
+
+```bash
+cd /Users/james/dev/gapless-crypto-data && uv run python -c "
+from gapless_crypto_data import fetch_data, MarketType
+print('MarketType.SPOT:', MarketType.SPOT)
+print('MarketType.FUTURES:', MarketType.FUTURES)
+print('SPOT base_path:', MarketType.SPOT.base_path)
+print('FUTURES base_path:', MarketType.FUTURES.base_path)
+"
+```
+
+Expected: Prints enum values and base paths correctly
+
+---
+
+## Summary
+
+| Task | Description | Tests |
+|------|-------------|-------|
+| 1 | Create MarketType enum | 9 tests |
+| 2 | Update HybridUrlGenerator | 5 tests |
+| 3 | Update BinancePublicDataCollector | 4 tests |
+| 4 | Update filename generation | 2 tests |
+| 5 | Update fetch_data() | 4 tests |
+| 6 | Update download() | 2 tests |
+| 7 | Update exports, deprecate symbols | - |
+| 8 | Fix existing tests | - |
+| 9 | Integration tests | 2 tests |
+| 10 | Version bump and docs | - |
+| 11 | Final validation | - |
+
+**Total new tests:** ~28 tests
+**Estimated implementation time:** 2-3 hours

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gapless-crypto-data"
-version = "5.0.0"
+version = "6.0.0"
 description = "Cryptocurrency OHLCV data collection with gap-free guarantee. Retrieves microstructure-enriched kline data from Binance Public Data Repository with automatic gap detection and filling."
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [

--- a/src/gapless_crypto_data/__init__.py
+++ b/src/gapless_crypto_data/__init__.py
@@ -1,40 +1,20 @@
 """
-Gapless Crypto Data - Binance USDT spot market OHLCV collection with gap-free guarantee.
+gapless-crypto-data: Zero-gaps cryptocurrency OHLCV data from Binance.
 
-Scope:
-    - USDT spot pairs only (BTCUSDT, ETHUSDT, SOLUSDT, etc.)
-    - No futures, perpetuals, derivatives, or margin data
+Supports both Spot and USDT-M Futures markets.
 
-Capabilities:
-    - Bulk historical data via Binance Public Data Repository
-    - Microstructure-enriched kline format (OHLCV + order flow metrics)
-    - Gap detection and API-based filling
-    - All Binance spot kline intervals supported
-
-Data Source:
-    https://data.binance.vision/data/spot/monthly/klines/
-
-Usage:
+Examples:
+    # Fetch spot data
     import gapless_crypto_data as gcd
+    df = gcd.fetch_data("BTCUSDT", market_type="spot", timeframe="1h")
 
-    # Fetch data
-    df = gcd.fetch_data("BTCUSDT", timeframe="1h", limit=1000)
-    df = gcd.download("ETHUSDT", timeframe="4h", start="2024-01-01", end="2024-06-30")
+    # Fetch futures data
+    df = gcd.fetch_data("BTCUSDT", market_type="futures", timeframe="1h")
 
-    # Discovery
-    symbols = gcd.get_supported_symbols()
-    timeframes = gcd.get_supported_timeframes()
-
-    # Gap filling
-    results = gcd.fill_gaps("./data")
-
-    # Class-based API
-    from gapless_crypto_data import BinancePublicDataCollector, UniversalGapFiller
-    collector = BinancePublicDataCollector()
-    result = collector.collect_timeframe_data("1h")
+Breaking change in v6.0.0: market_type parameter is now required.
 """
 
-__version__ = "5.0.0"
+__version__ = "6.0.0"
 __author__ = "Eon Labs"
 __email__ = "terry@eonlabs.com"
 

--- a/src/gapless_crypto_data/__init__.py
+++ b/src/gapless_crypto_data/__init__.py
@@ -64,6 +64,7 @@ from .exceptions import (
 )
 from .gap_filling.safe_file_operations import AtomicCSVOperations, SafeCSVMerger
 from .gap_filling.universal_gap_filler import UniversalGapFiller
+from .market_types import MarketType
 
 __all__ = [
     # Simple function-based API (recommended for most users)
@@ -89,4 +90,6 @@ __all__ = [
     "GapFillingError",
     # AI agent probe hooks
     "__probe__",
+    # Market type enum (v6.0.0)
+    "MarketType",
 ]

--- a/src/gapless_crypto_data/api.py
+++ b/src/gapless_crypto_data/api.py
@@ -29,6 +29,7 @@ import pandas as pd
 
 from .collectors.binance_public_data_collector import BinancePublicDataCollector
 from .gap_filling.universal_gap_filler import UniversalGapFiller
+from .market_types import MarketType
 
 # Timestamp columns requiring datetime64 conversion
 TIMESTAMP_COLUMNS = ("date", "close_time")
@@ -356,6 +357,7 @@ def _create_empty_dataframe() -> pd.DataFrame:
 
 def fetch_data(
     symbol: Union[str, SupportedSymbol],
+    market_type: str,
     timeframe: Optional[Union[str, SupportedTimeframe]] = None,
     limit: Optional[int] = None,
     start: Optional[str] = None,
@@ -376,6 +378,8 @@ def fetch_data(
 
     Args:
         symbol: Trading pair symbol (e.g., "BTCUSDT", "ETHUSDT")
+        market_type: Market type - 'spot' for spot market, 'futures' for USDT-M futures.
+            Required parameter with no default.
         timeframe: Timeframe interval (e.g., "1m", "5m", "1h", "4h", "1d")
         limit: Maximum number of recent bars to return (optional)
         start: Start date in YYYY-MM-DD format (optional)
@@ -396,9 +400,16 @@ def fetch_data(
         - taker_buy_base_asset_volume: Taker buy base volume
         - taker_buy_quote_asset_volume: Taker buy quote volume
 
+    Raises:
+        TypeError: If market_type is not provided.
+        ValueError: If market_type is not 'spot' or 'futures'.
+
     Examples:
-        # Simple data fetching
-        df = fetch_data("BTCUSDT", "1h", limit=1000)
+        # Simple data fetching (spot market)
+        df = fetch_data("BTCUSDT", "spot", "1h", limit=1000)
+
+        # Futures market data
+        df = fetch_data("BTCUSDT", "futures", "1h", limit=1000)
 
         # Standard pandas operations for analysis
         returns = df['close'].pct_change()                    # Returns calculation
@@ -409,14 +420,21 @@ def fetch_data(
         })  # OHLCV resampling
 
         # Fetch specific date range
-        df = fetch_data("ETHUSDT", "4h", start="2024-01-01", end="2024-06-30")
+        df = fetch_data("ETHUSDT", "spot", "4h", start="2024-01-01", end="2024-06-30")
 
         # Save to custom directory
-        df = fetch_data("SOLUSDT", "1h", limit=500, output_dir="./crypto_data")
+        df = fetch_data("SOLUSDT", "spot", "1h", limit=500, output_dir="./crypto_data")
 
         # Legacy interval parameter (deprecated)
-        df = fetch_data("BTCUSDT", interval="1h", limit=1000)
+        df = fetch_data("BTCUSDT", "spot", interval="1h", limit=1000)
     """
+    # Validate market_type (required parameter)
+    if market_type is None:
+        raise TypeError("market_type is required. Use 'spot' or 'futures'.")
+
+    # Convert string to enum (raises ValueError if invalid)
+    market_type_enum = MarketType(market_type)
+
     # Validate and resolve timeframe parameters
     period = _validate_timeframe_parameters(timeframe, interval)
 
@@ -431,7 +449,11 @@ def fetch_data(
 
     # Initialize collector and collect data
     collector = BinancePublicDataCollector(
-        symbol=symbol, start_date=start, end_date=end, output_dir=output_dir
+        market_type=market_type_enum,
+        symbol=symbol,
+        start_date=start,
+        end_date=end,
+        output_dir=output_dir,
     )
     result = collector.collect_timeframe_data(period)
 

--- a/src/gapless_crypto_data/api.py
+++ b/src/gapless_crypto_data/api.py
@@ -79,17 +79,8 @@ def get_supported_timeframes() -> List[str]:
 
     Returns:
         List of timeframe strings (e.g., ["1m", "5m", "1h", "4h", ...])
-
-    Examples:
-        >>> timeframes = get_supported_timeframes()
-        >>> print(f"Available timeframes: {timeframes}")
-        >>> print(f"1-hour supported: {'1h' in timeframes}")
-        Available timeframes: ['1s', '1m', '3m', '5m', '15m', '30m', '1h', '2h', '4h', '6h', '8h', '12h', '1d']
-        1-hour supported: True
     """
-    from .utils.timeframe_constants import TIMEFRAME_TO_MINUTES
-
-    return list(TIMEFRAME_TO_MINUTES.keys())
+    return ["1s", "1m", "3m", "5m", "15m", "30m", "1h", "2h", "4h", "6h", "8h", "12h", "1d", "3d", "1w", "1mo"]
 
 
 # Type aliases for better discoverability and coding agent support

--- a/src/gapless_crypto_data/api.py
+++ b/src/gapless_crypto_data/api.py
@@ -84,11 +84,12 @@ def get_supported_timeframes() -> List[str]:
         >>> timeframes = get_supported_timeframes()
         >>> print(f"Available timeframes: {timeframes}")
         >>> print(f"1-hour supported: {'1h' in timeframes}")
-        Available timeframes: ['1s', '1m', '3m', '5m', '15m', '30m', '1h', '2h', '4h', '6h', '8h', '12h', '1d', '3d', '1w', '1mo']
+        Available timeframes: ['1s', '1m', '3m', '5m', '15m', '30m', '1h', '2h', '4h', '6h', '8h', '12h', '1d']
         1-hour supported: True
     """
-    collector = BinancePublicDataCollector()
-    return collector.available_timeframes
+    from .utils.timeframe_constants import TIMEFRAME_TO_MINUTES
+
+    return list(TIMEFRAME_TO_MINUTES.keys())
 
 
 # Type aliases for better discoverability and coding agent support

--- a/src/gapless_crypto_data/api.py
+++ b/src/gapless_crypto_data/api.py
@@ -473,6 +473,7 @@ def fetch_data(
 
 def download(
     symbol: Union[str, SupportedSymbol],
+    market_type: str,
     timeframe: Optional[Union[str, SupportedTimeframe]] = None,
     start: Optional[str] = None,
     end: Optional[str] = None,
@@ -490,6 +491,8 @@ def download(
 
     Args:
         symbol: Trading pair symbol (e.g., "BTCUSDT")
+        market_type: Market type - 'spot' for spot market, 'futures' for USDT-M futures.
+            Required parameter with no default.
         timeframe: Timeframe interval (default: "1h" if neither specified)
         start: Start date in YYYY-MM-DD format
         end: End date in YYYY-MM-DD format
@@ -501,22 +504,34 @@ def download(
     Returns:
         pd.DataFrame with complete OHLCV and microstructure data (gapless by default)
 
+    Raises:
+        TypeError: If market_type is not provided.
+        ValueError: If market_type is not 'spot' or 'futures'.
+
     Examples:
         # Simple data download (automatically fills gaps)
-        df = download("BTCUSDT", "1h", start="2024-01-01", end="2024-06-30")
+        df = download("BTCUSDT", "spot", "1h", start="2024-01-01", end="2024-06-30")
+
+        # Futures market data
+        df = download("BTCUSDT", "futures", "1h", start="2024-01-01", end="2024-06-30")
 
         # Disable auto-fill if you want raw Vision archive data
-        df = download("ETHUSDT", "4h", auto_fill_gaps=False)
+        df = download("ETHUSDT", "spot", "4h", auto_fill_gaps=False)
 
         # Legacy interval parameter
-        df = download("BTCUSDT", interval="1h")
+        df = download("BTCUSDT", "spot", interval="1h")
     """
+    # Validate market_type (required parameter)
+    if market_type is None:
+        raise TypeError("market_type is required. Use 'spot' or 'futures'.")
+
     # Apply default if neither parameter specified
     if timeframe is None and interval is None:
         timeframe = "1h"
 
     return fetch_data(
         symbol=symbol,
+        market_type=market_type,
         timeframe=timeframe,
         start=start,
         end=end,

--- a/src/gapless_crypto_data/api.py
+++ b/src/gapless_crypto_data/api.py
@@ -54,20 +54,24 @@ def _ensure_datetime_types(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def get_supported_symbols() -> List[str]:
-    """Get list of supported USDT spot trading pairs.
+    """Get list of supported trading pairs.
+
+    .. deprecated::
+        This function is deprecated and will be removed in v7.0.0.
+        Symbol validation is no longer performed. Use any valid Binance symbol.
 
     Returns:
-        List of supported symbol strings (e.g., ["BTCUSDT", "ETHUSDT", ...])
-
-    Examples:
-        >>> symbols = get_supported_symbols()
-        >>> print(f"Found {len(symbols)} supported symbols")
-        >>> print(f"Bitcoin: {'BTCUSDT' in symbols}")
-        Found 6 supported symbols
-        Bitcoin: True
+        Empty list (function deprecated)
     """
-    collector = BinancePublicDataCollector()
-    return list(collector.known_symbols.keys())
+    import warnings
+
+    warnings.warn(
+        "get_supported_symbols() is deprecated and will be removed in v7.0.0. "
+        "Symbol validation is no longer performed. Use any valid Binance symbol.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return []
 
 
 def get_supported_timeframes() -> List[str]:

--- a/src/gapless_crypto_data/collectors/binance_public_data_collector.py
+++ b/src/gapless_crypto_data/collectors/binance_public_data_collector.py
@@ -28,6 +28,7 @@ from ..gap_filling.universal_gap_filler import UniversalGapFiller
 from ..utils.etag_cache import ETagCache
 from ..utils.timeframe_constants import TIMEFRAME_TO_MINUTES
 from ..utils.timestamp_format_analyzer import TimestampFormatAnalyzer
+from ..market_types import MarketType
 from ..validation.csv_validator import CSVValidator
 
 
@@ -153,6 +154,7 @@ class BinancePublicDataCollector:
 
     def __init__(
         self,
+        market_type: MarketType,
         symbol: str = "SOLUSDT",
         start_date: str = "2020-08-15",
         end_date: str = "2025-03-20",
@@ -162,6 +164,10 @@ class BinancePublicDataCollector:
         """Initialize the Binance Public Data Collector.
 
         Args:
+            market_type (MarketType): Market type for data collection.
+                MarketType.SPOT for spot market data.
+                MarketType.FUTURES for USDT-M futures market data.
+                Required parameter (no default).
             symbol (str, optional): Trading pair symbol in USDT format.
                 Must be alphanumeric (A-Z, 0-9) only. Path characters (/, \\, .)
                 and special characters are rejected for security.
@@ -215,6 +221,9 @@ class BinancePublicDataCollector:
             ...     output_format="parquet"
             ... )
         """
+        # Store market type
+        self.market_type = market_type
+
         # Validate and assign symbol (SEC-01, SEC-02, SEC-03)
         self.symbol = self._validate_symbol(symbol)
 
@@ -234,7 +243,7 @@ class BinancePublicDataCollector:
                 f"Invalid date range: end_date ({self.end_date.strftime('%Y-%m-%d')}) "
                 f"is before start_date ({self.start_date.strftime('%Y-%m-%d')})"
             )
-        self.base_url = "https://data.binance.vision/data/spot/monthly/klines"
+        self.base_url = f"https://data.binance.vision/data/{market_type.base_path}/monthly/klines"
 
         # Initialize ETag cache for bandwidth optimization (90% reduction on re-runs)
         self.etag_cache = ETagCache()

--- a/src/gapless_crypto_data/collectors/binance_public_data_collector.py
+++ b/src/gapless_crypto_data/collectors/binance_public_data_collector.py
@@ -1141,7 +1141,7 @@ class BinancePublicDataCollector:
         end_date_str = datetime.strptime(data[-1][0], "%Y-%m-%d %H:%M:%S").strftime("%Y%m%d")
         version = "v2.10.0"  # Updated version for Parquet support
         file_extension = self.output_format
-        filename = f"binance_spot_{self.symbol}-{timeframe}_{start_date_str}-{end_date_str}_{version}.{file_extension}"
+        filename = f"{self.market_type.filename_prefix}{self.symbol}-{timeframe}_{start_date_str}-{end_date_str}_{version}.{file_extension}"
         filepath = self.output_dir / filename
 
         # Ensure output directory exists

--- a/src/gapless_crypto_data/collectors/hybrid_url_generator.py
+++ b/src/gapless_crypto_data/collectors/hybrid_url_generator.py
@@ -15,6 +15,8 @@ from datetime import datetime, timedelta
 from enum import Enum
 from typing import List, NamedTuple, Optional, Tuple
 
+from gapless_crypto_data.market_types import MarketType
+
 
 class DataSource(Enum):
     """Data source types for Binance public data."""
@@ -50,9 +52,10 @@ class HybridUrlGenerator:
         - Intelligent overlap handling between monthly and daily sources
 
     Examples:
-        Basic hybrid URL generation:
+        Basic hybrid URL generation for spot market:
 
-        >>> generator = HybridUrlGenerator()
+        >>> from gapless_crypto_data.market_types import MarketType
+        >>> generator = HybridUrlGenerator(market_type=MarketType.SPOT)
         >>> tasks = generator.generate_download_tasks(
         ...     symbol="BTCUSDT",
         ...     timeframe="1h",
@@ -62,11 +65,11 @@ class HybridUrlGenerator:
         >>> print(f"Generated {len(tasks)} download tasks")
         Generated 15 download tasks
 
-        Custom configuration:
+        Futures market with custom configuration:
 
         >>> generator = HybridUrlGenerator(
+        ...     market_type=MarketType.FUTURES,
         ...     daily_lookback_days=45,  # Use daily files for last 45 days
-        ...     base_url="https://data.binance.vision/data/spot"
         ... )
         >>> monthly_tasks, daily_tasks = generator.separate_tasks_by_source(tasks)
         >>> print(f"Monthly: {len(monthly_tasks)}, Daily: {len(daily_tasks)}")
@@ -83,20 +86,21 @@ class HybridUrlGenerator:
 
     def __init__(
         self,
+        market_type: MarketType,
         daily_lookback_days: int = 30,
-        base_url: str = "https://data.binance.vision/data/spot",
         max_concurrent_per_batch: int = 13,
     ):
         """
         Initialize hybrid URL generator with configuration.
 
         Args:
+            market_type: Market type (SPOT or FUTURES) - determines base URL
             daily_lookback_days: Number of days to use daily files for recent data
-            base_url: Base URL for Binance data repository
             max_concurrent_per_batch: Maximum concurrent downloads per batch (13 for ZIP files)
         """
+        self.market_type = market_type
         self.daily_lookback_days = daily_lookback_days
-        self.base_url = base_url.rstrip("/")
+        self.base_url = f"https://data.binance.vision/data/{market_type.base_path}"
         self.max_concurrent_per_batch = max_concurrent_per_batch
 
         # Calculate cutoff date for monthly vs daily strategy

--- a/src/gapless_crypto_data/market_types.py
+++ b/src/gapless_crypto_data/market_types.py
@@ -1,0 +1,61 @@
+"""Market type enum for Binance data sources.
+
+Supports both Spot and USDT-M Futures markets from Binance Vision.
+
+Usage:
+    from gapless_crypto_data.market_types import MarketType
+
+    # Use enum values
+    market = MarketType.SPOT
+    market = MarketType.FUTURES
+
+    # Create from string
+    market = MarketType("spot")
+    market = MarketType("futures")
+
+    # Access properties
+    path = market.base_path       # "spot" or "futures/um"
+    prefix = market.filename_prefix  # "binance_spot_" or "binance_futures_"
+"""
+
+from enum import Enum
+
+
+class MarketType(str, Enum):
+    """Binance market type for data collection.
+
+    Attributes:
+        SPOT: Binance spot market (BTCUSDT, ETHUSDT, etc.)
+        FUTURES: Binance USDT-M futures market (perpetual contracts)
+
+    Properties:
+        base_path: Path segment for Binance Vision URLs
+        filename_prefix: Prefix for output filenames
+    """
+
+    SPOT = "spot"
+    FUTURES = "futures"
+
+    def __str__(self) -> str:
+        """Return the string value of the enum."""
+        return self.value
+
+    @property
+    def base_path(self) -> str:
+        """Return the base path segment for Binance Vision URLs.
+
+        Returns:
+            str: "spot" for spot market, "futures/um" for USDT-M futures
+        """
+        if self == MarketType.SPOT:
+            return "spot"
+        return "futures/um"
+
+    @property
+    def filename_prefix(self) -> str:
+        """Return the prefix for output filenames.
+
+        Returns:
+            str: "binance_spot_" or "binance_futures_"
+        """
+        return f"binance_{self.value}_"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+from gapless_crypto_data.market_types import MarketType
+
 
 @pytest.fixture
 def test_data_dir():
@@ -61,6 +63,7 @@ def real_btcusdt_1h_sample(tmp_path_factory):
     try:
         # Download real Binance data once
         collector = BinancePublicDataCollector(
+            market_type=MarketType.SPOT,
             symbol="BTCUSDT",
             start_date="2024-01-01",
             end_date="2024-01-02",

--- a/tests/test_1s_1d_gap_filling.py
+++ b/tests/test_1s_1d_gap_filling.py
@@ -522,9 +522,10 @@ class TestConcurrentDownloadWith1sAnd1d:
         """Test that concurrent collection architecture supports 1s and 1d."""
         # Import concurrent components
         from gapless_crypto_data.collectors.hybrid_url_generator import HybridUrlGenerator
+        from gapless_crypto_data.market_types import MarketType
 
         # Test URL generation for 1s
-        url_generator = HybridUrlGenerator()
+        url_generator = HybridUrlGenerator(market_type=MarketType.SPOT)
 
         # Test with very short date range for 1s (to avoid massive datasets)
         start_date = datetime(2025, 9, 18, 12, 0, 0)

--- a/tests/test_api_edge_cases.py
+++ b/tests/test_api_edge_cases.py
@@ -181,7 +181,7 @@ class TestGetInfo:
     def test_get_info_structure(self):
         """Test get_info returns expected structure."""
         info = gcd.get_info()
-        assert info["version"] == "3.2.0"
+        assert info["version"] == "5.0.0"
         assert info["name"] == "gapless-crypto-data"
         assert "description" in info
         assert "supported_symbols" in info

--- a/tests/test_api_edge_cases.py
+++ b/tests/test_api_edge_cases.py
@@ -181,7 +181,7 @@ class TestGetInfo:
     def test_get_info_structure(self):
         """Test get_info returns expected structure."""
         info = gcd.get_info()
-        assert info["version"] == "5.0.0"
+        assert info["version"] == "6.0.0"
         assert info["name"] == "gapless-crypto-data"
         assert "description" in info
         assert "supported_symbols" in info

--- a/tests/test_api_market_type.py
+++ b/tests/test_api_market_type.py
@@ -1,0 +1,73 @@
+"""Tests for market_type parameter in fetch_data() API."""
+
+import pytest
+
+
+class TestMarketTypeParameter:
+    """Tests for the required market_type parameter in fetch_data()."""
+
+    def test_market_type_required(self):
+        """Verify TypeError when market_type is missing."""
+        from gapless_crypto_data.api import fetch_data
+
+        # fetch_data without market_type should raise TypeError
+        with pytest.raises(TypeError) as exc_info:
+            fetch_data("BTCUSDT", timeframe="1h", limit=10)
+
+        # Verify error message mentions market_type is required
+        assert "market_type" in str(exc_info.value).lower()
+
+    def test_market_type_spot_accepted(self):
+        """Verify 'spot' is accepted as market_type (validation passes)."""
+        from gapless_crypto_data.api import fetch_data
+
+        # This should not raise ValueError for invalid market_type
+        # It may fail later in the fetch process, but market_type validation should pass
+        try:
+            # Use very short date range to minimize actual fetching
+            fetch_data(
+                "BTCUSDT",
+                "spot",
+                timeframe="1h",
+                start="2024-01-01",
+                end="2024-01-01",
+                limit=1,
+            )
+        except ValueError as e:
+            # If ValueError is raised, it should NOT be about invalid market_type
+            assert "market_type" not in str(e).lower() or "invalid" not in str(e).lower()
+        except Exception:
+            # Other exceptions (network, etc.) are acceptable - we're only testing validation
+            pass
+
+    def test_market_type_futures_accepted(self):
+        """Verify 'futures' is accepted as market_type (validation passes)."""
+        from gapless_crypto_data.api import fetch_data
+
+        # This should not raise ValueError for invalid market_type
+        try:
+            fetch_data(
+                "BTCUSDT",
+                "futures",
+                timeframe="1h",
+                start="2024-01-01",
+                end="2024-01-01",
+                limit=1,
+            )
+        except ValueError as e:
+            # If ValueError is raised, it should NOT be about invalid market_type
+            assert "market_type" not in str(e).lower() or "invalid" not in str(e).lower()
+        except Exception:
+            # Other exceptions (network, etc.) are acceptable - we're only testing validation
+            pass
+
+    def test_invalid_market_type_raises(self):
+        """Verify ValueError for invalid market_type value."""
+        from gapless_crypto_data.api import fetch_data
+
+        with pytest.raises(ValueError) as exc_info:
+            fetch_data("BTCUSDT", "invalid", timeframe="1h", limit=10)
+
+        # The error should mention the invalid value
+        error_msg = str(exc_info.value).lower()
+        assert "invalid" in error_msg or "market" in error_msg

--- a/tests/test_api_market_type.py
+++ b/tests/test_api_market_type.py
@@ -71,3 +71,32 @@ class TestMarketTypeParameter:
         # The error should mention the invalid value
         error_msg = str(exc_info.value).lower()
         assert "invalid" in error_msg or "market" in error_msg
+
+
+class TestDownloadMarketType:
+    """Tests for market_type parameter in download()."""
+
+    def test_market_type_required(self):
+        """download raises TypeError when market_type is missing."""
+        from gapless_crypto_data import download
+
+        with pytest.raises(TypeError) as exc_info:
+            download(symbol="BTCUSDT", timeframe="1h")
+        # Python raises TypeError for missing required positional argument
+        assert "market_type" in str(exc_info.value)
+
+    def test_market_type_passed_to_fetch_data(self):
+        """download passes market_type to fetch_data."""
+        from gapless_crypto_data import download
+
+        try:
+            download(
+                symbol="BTCUSDT",
+                market_type="futures",
+                timeframe="1d",
+                start="2024-01-01",
+                end="2024-01-01",
+            )
+        except Exception as e:
+            # Should not be a market_type validation error
+            assert "market_type" not in str(e).lower()

--- a/tests/test_binance_collector.py
+++ b/tests/test_binance_collector.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 
 from gapless_crypto_data.collectors.binance_public_data_collector import BinancePublicDataCollector
+from gapless_crypto_data.market_types import MarketType
 from gapless_crypto_data.utils.timestamp_format_analyzer import TimestampFormatAnalyzer
 from gapless_crypto_data.validation import CSVValidator
 
@@ -16,14 +17,17 @@ class TestBinancePublicDataCollector:
 
     def test_init(self):
         """Test collector initialization."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
         assert collector is not None
         assert hasattr(collector, "collect_timeframe_data")
 
     def test_init_with_custom_params(self):
         """Test collector initialization with custom parameters."""
         collector = BinancePublicDataCollector(
-            symbol="BTCUSDT", start_date="2023-01-01", end_date="2023-12-31"
+            market_type=MarketType.SPOT,
+            symbol="BTCUSDT",
+            start_date="2023-01-01",
+            end_date="2023-12-31",
         )
         assert collector.symbol == "BTCUSDT"
 
@@ -69,7 +73,10 @@ class TestBinancePublicDataCollector:
     def test_collect_small_dataset(self):
         """Integration test for collecting a small dataset."""
         collector = BinancePublicDataCollector(
-            symbol="BTCUSDT", start_date="2024-01-01", end_date="2024-01-02"
+            market_type=MarketType.SPOT,
+            symbol="BTCUSDT",
+            start_date="2024-01-01",
+            end_date="2024-01-02",
         )
 
         # Test with a very small date range to minimize download time
@@ -180,7 +187,7 @@ class TestBinancePublicDataCollector:
 
     def test_analyze_timestamp_format_invalid(self):
         """Test timestamp format analysis with invalid timestamps."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
 
         # Test invalid timestamp formats
         invalid_timestamps = [
@@ -621,7 +628,10 @@ class TestInputValidationSecurity:
         for malicious_symbol in path_traversal_attempts:
             with pytest.raises(ValueError, match="invalid characters"):
                 BinancePublicDataCollector(
-                    symbol=malicious_symbol, start_date="2024-01-01", end_date="2024-01-31"
+                    market_type=MarketType.SPOT,
+                    symbol=malicious_symbol,
+                    start_date="2024-01-01",
+                    end_date="2024-01-31",
                 )
 
     def test_sec01_dot_characters_rejected(self):
@@ -631,7 +641,10 @@ class TestInputValidationSecurity:
         for symbol in dot_symbols:
             with pytest.raises(ValueError, match="invalid characters"):
                 BinancePublicDataCollector(
-                    symbol=symbol, start_date="2024-01-01", end_date="2024-01-31"
+                    market_type=MarketType.SPOT,
+                    symbol=symbol,
+                    start_date="2024-01-01",
+                    end_date="2024-01-31",
                 )
 
     def test_sec01_slash_characters_rejected(self):
@@ -647,7 +660,10 @@ class TestInputValidationSecurity:
         for symbol in slash_symbols:
             with pytest.raises(ValueError, match="invalid characters"):
                 BinancePublicDataCollector(
-                    symbol=symbol, start_date="2024-01-01", end_date="2024-01-31"
+                    market_type=MarketType.SPOT,
+                    symbol=symbol,
+                    start_date="2024-01-01",
+                    end_date="2024-01-31",
                 )
 
     def test_sec02_empty_symbol_rejected(self):
@@ -657,26 +673,40 @@ class TestInputValidationSecurity:
         for symbol in empty_symbols:
             with pytest.raises(ValueError, match="cannot be empty"):
                 BinancePublicDataCollector(
-                    symbol=symbol, start_date="2024-01-01", end_date="2024-01-31"
+                    market_type=MarketType.SPOT,
+                    symbol=symbol,
+                    start_date="2024-01-01",
+                    end_date="2024-01-31",
                 )
 
     def test_sec03_none_symbol_rejected(self):
         """SEC-03: Test that None symbol is rejected."""
         with pytest.raises(ValueError, match="cannot be None"):
-            BinancePublicDataCollector(symbol=None, start_date="2024-01-01", end_date="2024-01-31")
+            BinancePublicDataCollector(
+                market_type=MarketType.SPOT,
+                symbol=None,
+                start_date="2024-01-01",
+                end_date="2024-01-31",
+            )
 
     def test_sec04_invalid_date_range_rejected(self):
         """SEC-04: Test that invalid date ranges (end before start) are rejected."""
         with pytest.raises(ValueError, match="before start_date"):
             BinancePublicDataCollector(
-                symbol="BTCUSDT", start_date="2024-12-31", end_date="2024-01-01"
+                market_type=MarketType.SPOT,
+                symbol="BTCUSDT",
+                start_date="2024-12-31",
+                end_date="2024-01-01",
             )
 
     def test_sec04_same_date_range_accepted(self):
         """SEC-04: Test that same start and end dates are accepted."""
         # Same date should be valid (single day)
         collector = BinancePublicDataCollector(
-            symbol="BTCUSDT", start_date="2024-01-01", end_date="2024-01-01"
+            market_type=MarketType.SPOT,
+            symbol="BTCUSDT",
+            start_date="2024-01-01",
+            end_date="2024-01-01",
         )
         assert collector.symbol == "BTCUSDT"
 
@@ -686,7 +716,10 @@ class TestInputValidationSecurity:
 
         for symbol in valid_symbols:
             collector = BinancePublicDataCollector(
-                symbol=symbol, start_date="2024-01-01", end_date="2024-01-31"
+                market_type=MarketType.SPOT,
+                symbol=symbol,
+                start_date="2024-01-01",
+                end_date="2024-01-31",
             )
             # Should normalize to uppercase
             assert collector.symbol == symbol.upper()
@@ -702,7 +735,10 @@ class TestInputValidationSecurity:
 
         for input_symbol, expected_symbol in test_cases:
             collector = BinancePublicDataCollector(
-                symbol=input_symbol, start_date="2024-01-01", end_date="2024-01-31"
+                market_type=MarketType.SPOT,
+                symbol=input_symbol,
+                start_date="2024-01-01",
+                end_date="2024-01-31",
             )
             assert collector.symbol == expected_symbol
 
@@ -728,7 +764,10 @@ class TestInputValidationSecurity:
         for symbol in special_chars:
             with pytest.raises(ValueError, match="alphanumeric"):
                 BinancePublicDataCollector(
-                    symbol=symbol, start_date="2024-01-01", end_date="2024-01-31"
+                    market_type=MarketType.SPOT,
+                    symbol=symbol,
+                    start_date="2024-01-01",
+                    end_date="2024-01-31",
                 )
 
     def test_unicode_characters_rejected(self):
@@ -745,7 +784,10 @@ class TestInputValidationSecurity:
         for symbol in unicode_symbols:
             with pytest.raises(ValueError, match="alphanumeric"):
                 BinancePublicDataCollector(
-                    symbol=symbol, start_date="2024-01-01", end_date="2024-01-31"
+                    market_type=MarketType.SPOT,
+                    symbol=symbol,
+                    start_date="2024-01-01",
+                    end_date="2024-01-31",
                 )
 
     def test_sql_injection_rejected(self):
@@ -759,7 +801,10 @@ class TestInputValidationSecurity:
         for symbol in sql_injections:
             with pytest.raises(ValueError):
                 BinancePublicDataCollector(
-                    symbol=symbol, start_date="2024-01-01", end_date="2024-01-31"
+                    market_type=MarketType.SPOT,
+                    symbol=symbol,
+                    start_date="2024-01-01",
+                    end_date="2024-01-31",
                 )
 
     def test_command_injection_rejected(self):
@@ -774,7 +819,10 @@ class TestInputValidationSecurity:
         for symbol in command_injections:
             with pytest.raises(ValueError):
                 BinancePublicDataCollector(
-                    symbol=symbol, start_date="2024-01-01", end_date="2024-01-31"
+                    market_type=MarketType.SPOT,
+                    symbol=symbol,
+                    start_date="2024-01-01",
+                    end_date="2024-01-31",
                 )
 
     def test_invalid_date_format_rejected(self):
@@ -789,7 +837,10 @@ class TestInputValidationSecurity:
         for start_date, end_date in invalid_dates:
             with pytest.raises(ValueError):
                 BinancePublicDataCollector(
-                    symbol="BTCUSDT", start_date=start_date, end_date=end_date
+                    market_type=MarketType.SPOT,
+                    symbol="BTCUSDT",
+                    start_date=start_date,
+                    end_date=end_date,
                 )
 
     def test_extremely_long_symbol_rejected(self):
@@ -800,7 +851,10 @@ class TestInputValidationSecurity:
         # Should still be rejected even though alphanumeric
         # In practice, no valid symbol is this long
         collector = BinancePublicDataCollector(
-            symbol=long_symbol, start_date="2024-01-01", end_date="2024-01-31"
+            market_type=MarketType.SPOT,
+            symbol=long_symbol,
+            start_date="2024-01-01",
+            end_date="2024-01-31",
         )
         # Should be normalized to uppercase
         assert collector.symbol == long_symbol.upper()
@@ -815,7 +869,10 @@ class TestInputValidationSecurity:
 
         for start_date, end_date in valid_ranges:
             collector = BinancePublicDataCollector(
-                symbol="BTCUSDT", start_date=start_date, end_date=end_date
+                market_type=MarketType.SPOT,
+                symbol="BTCUSDT",
+                start_date=start_date,
+                end_date=end_date,
             )
             assert (
                 collector.start_date < collector.end_date
@@ -824,7 +881,7 @@ class TestInputValidationSecurity:
 
     def test_validate_symbol_method_directly(self):
         """Test _validate_symbol method directly."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
 
         # Valid symbols
         assert collector._validate_symbol("BTCUSDT") == "BTCUSDT"

--- a/tests/test_binance_collector_advanced.py
+++ b/tests/test_binance_collector_advanced.py
@@ -17,6 +17,7 @@ import pytest
 from gapless_crypto_data.collectors.binance_public_data_collector import (
     BinancePublicDataCollector,
 )
+from gapless_crypto_data.market_types import MarketType
 
 
 class TestETagCaching:
@@ -24,13 +25,13 @@ class TestETagCaching:
 
     def test_etag_cache_initialization(self):
         """Test that ETag cache is initialized on collector creation."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
         assert hasattr(collector, "etag_cache")
         assert collector.etag_cache is not None
 
     def test_etag_cache_directory_creation(self):
         """Test that cache directory is created properly."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
         # Cache should have a cache_dir attribute
         assert hasattr(collector.etag_cache, "cache_dir")
         assert isinstance(collector.etag_cache.cache_dir, Path)
@@ -41,7 +42,7 @@ class TestGapAnalysis:
 
     def test_perform_gap_analysis_no_data(self):
         """Test gap analysis with empty dataset."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
         result = collector._perform_gap_analysis([], "1h")
 
         assert result["analysis_performed"] is True
@@ -51,7 +52,7 @@ class TestGapAnalysis:
 
     def test_perform_gap_analysis_single_row(self):
         """Test gap analysis with insufficient data (< 2 rows)."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
         single_row_data = [["2024-01-01 00:00:00", 100, 105, 95, 102, 1000]]
 
         result = collector._perform_gap_analysis(single_row_data, "1h")
@@ -62,7 +63,7 @@ class TestGapAnalysis:
 
     def test_perform_gap_analysis_continuous_data(self):
         """Test gap analysis with continuous data (no gaps)."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
 
         # Create continuous hourly data
         continuous_data = [
@@ -81,7 +82,7 @@ class TestGapAnalysis:
 
     def test_perform_gap_analysis_with_gaps(self):
         """Test gap analysis with data containing gaps."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
 
         # Create data with gaps (missing 2:00 and 3:00)
         gapped_data = [
@@ -110,7 +111,7 @@ class TestGapAnalysis:
 
     def test_perform_gap_analysis_different_timeframes(self):
         """Test gap analysis with different timeframes (5m, 15m, 4h)."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
 
         # Test 5-minute timeframe
         five_min_data = [
@@ -141,7 +142,7 @@ class TestDataHashCalculation:
 
     def test_calculate_data_hash_consistent(self):
         """Test that hash calculation is consistent for same data."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
 
         test_data = [
             ["2024-01-01 00:00:00", 100, 105, 95, 102, 1000],
@@ -157,7 +158,7 @@ class TestDataHashCalculation:
 
     def test_calculate_data_hash_different_data(self):
         """Test that different data produces different hashes."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
 
         data1 = [["2024-01-01 00:00:00", 100, 105, 95, 102, 1000]]
         data2 = [["2024-01-01 00:00:00", 101, 105, 95, 102, 1000]]  # Different open price
@@ -169,7 +170,7 @@ class TestDataHashCalculation:
 
     def test_calculate_data_hash_empty_data(self):
         """Test hash calculation with empty data."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
 
         empty_hash = collector._calculate_data_hash([])
 
@@ -182,7 +183,7 @@ class TestMetadataGeneration:
 
     def test_generate_metadata_structure(self):
         """Test that metadata has all required fields."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
 
         test_data = [
             [
@@ -250,7 +251,7 @@ class TestMetadataGeneration:
 
     def test_generate_metadata_empty_data(self):
         """Test metadata generation with empty dataset."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
 
         metadata = collector.generate_metadata("1h", [], {})
 
@@ -258,7 +259,7 @@ class TestMetadataGeneration:
 
     def test_generate_metadata_statistics(self):
         """Test that statistics are calculated correctly."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
 
         test_data = [
             [
@@ -305,7 +306,7 @@ class TestMetadataGeneration:
 
     def test_generate_metadata_data_integrity(self):
         """Test data integrity section in metadata."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
 
         test_data = [
             [
@@ -342,7 +343,9 @@ class TestDataSaving:
     def test_save_data_csv_format(self):
         """Test saving data in CSV format."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            collector = BinancePublicDataCollector(output_dir=tmpdir, output_format="csv")
+            collector = BinancePublicDataCollector(
+                market_type=MarketType.SPOT, output_dir=tmpdir, output_format="csv"
+            )
 
             test_data = [
                 [
@@ -401,7 +404,9 @@ class TestDataSaving:
     def test_save_data_parquet_format(self):
         """Test saving data in Parquet format."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            collector = BinancePublicDataCollector(output_dir=tmpdir, output_format="parquet")
+            collector = BinancePublicDataCollector(
+                market_type=MarketType.SPOT, output_dir=tmpdir, output_format="parquet"
+            )
 
             test_data = [
                 [
@@ -460,7 +465,7 @@ class TestDataSaving:
     def test_save_data_empty_dataset(self):
         """Test saving empty dataset returns None."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            collector = BinancePublicDataCollector(output_dir=tmpdir)
+            collector = BinancePublicDataCollector(market_type=MarketType.SPOT, output_dir=tmpdir)
 
             filepath = collector.save_data("1h", [], {})
 
@@ -470,7 +475,9 @@ class TestDataSaving:
         """Test that save_data creates output directory if it doesn't exist."""
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = Path(tmpdir) / "nested" / "output"
-            collector = BinancePublicDataCollector(output_dir=str(output_path))
+            collector = BinancePublicDataCollector(
+                market_type=MarketType.SPOT, output_dir=str(output_path)
+            )
 
             test_data = [
                 [
@@ -506,7 +513,7 @@ class TestTimeframeExtraction:
 
     def test_extract_timeframe_from_filename_valid(self):
         """Test extracting valid timeframes from filenames."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
 
         test_cases = [
             ("BTCUSDT-1h_2024-01-01.csv", "1h"),
@@ -523,7 +530,7 @@ class TestTimeframeExtraction:
 
     def test_extract_timeframe_from_filename_default(self):
         """Test default timeframe when none found in filename."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
 
         # Filename with no timeframe
         result = collector._extract_timeframe_from_filename("BTCUSDT_data.csv")
@@ -537,19 +544,21 @@ class TestOutputFormatValidation:
     def test_invalid_output_format_rejected(self):
         """Test that invalid output formats are rejected."""
         with pytest.raises(ValueError, match="output_format must be"):
-            BinancePublicDataCollector(output_format="json")
+            BinancePublicDataCollector(market_type=MarketType.SPOT, output_format="json")
 
         with pytest.raises(ValueError, match="output_format must be"):
-            BinancePublicDataCollector(output_format="xlsx")
+            BinancePublicDataCollector(market_type=MarketType.SPOT, output_format="xlsx")
 
     def test_valid_output_formats_accepted(self):
         """Test that valid output formats are accepted."""
         # CSV format
-        collector_csv = BinancePublicDataCollector(output_format="csv")
+        collector_csv = BinancePublicDataCollector(market_type=MarketType.SPOT, output_format="csv")
         assert collector_csv.output_format == "csv"
 
         # Parquet format
-        collector_parquet = BinancePublicDataCollector(output_format="parquet")
+        collector_parquet = BinancePublicDataCollector(
+            market_type=MarketType.SPOT, output_format="parquet"
+        )
         assert collector_parquet.output_format == "parquet"
 
 
@@ -559,7 +568,10 @@ class TestMonthlyURLGeneration:
     def test_generate_monthly_urls_single_month(self):
         """Test URL generation for single month."""
         collector = BinancePublicDataCollector(
-            symbol="BTCUSDT", start_date="2024-01-01", end_date="2024-01-31"
+            market_type=MarketType.SPOT,
+            symbol="BTCUSDT",
+            start_date="2024-01-01",
+            end_date="2024-01-31",
         )
 
         urls = collector.generate_monthly_urls("1h")
@@ -575,7 +587,10 @@ class TestMonthlyURLGeneration:
     def test_generate_monthly_urls_multi_month(self):
         """Test URL generation spanning multiple months."""
         collector = BinancePublicDataCollector(
-            symbol="ETHUSDT", start_date="2024-01-01", end_date="2024-03-31"
+            market_type=MarketType.SPOT,
+            symbol="ETHUSDT",
+            start_date="2024-01-01",
+            end_date="2024-03-31",
         )
 
         urls = collector.generate_monthly_urls("1h")
@@ -588,7 +603,10 @@ class TestMonthlyURLGeneration:
     def test_generate_monthly_urls_year_boundary(self):
         """Test URL generation across year boundary."""
         collector = BinancePublicDataCollector(
-            symbol="SOLUSDT", start_date="2023-11-01", end_date="2024-02-28"
+            market_type=MarketType.SPOT,
+            symbol="SOLUSDT",
+            start_date="2023-11-01",
+            end_date="2024-02-28",
         )
 
         urls = collector.generate_monthly_urls("1h")
@@ -605,7 +623,7 @@ class TestHeaderDetection:
 
     def test_detect_header_with_header_row(self):
         """Test detection when CSV has header row."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
 
         # CSV with header row (non-numeric first field)
         csv_with_header = [
@@ -619,7 +637,7 @@ class TestHeaderDetection:
 
     def test_detect_header_without_header_row(self):
         """Test detection when CSV has no header (pure data)."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
 
         # CSV without header (numeric timestamp in first row)
         csv_no_header = [
@@ -633,7 +651,7 @@ class TestHeaderDetection:
 
     def test_detect_header_empty_data(self):
         """Test header detection with empty data."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
 
         has_header = collector._detect_header_intelligent([])
 
@@ -641,7 +659,7 @@ class TestHeaderDetection:
 
     def test_detect_header_insufficient_columns(self):
         """Test header detection with insufficient columns."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
 
         # Less than 6 columns
         insufficient_data = [["timestamp", "open", "high"]]
@@ -652,7 +670,7 @@ class TestHeaderDetection:
 
     def test_detect_header_invalid_timestamp(self):
         """Test header detection with invalid timestamp (indicates header)."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
 
         # First field is not a valid timestamp
         csv_with_text = [

--- a/tests/test_binance_collector_market_type.py
+++ b/tests/test_binance_collector_market_type.py
@@ -66,3 +66,27 @@ class TestBinanceCollectorMarketType:
         )
 
         assert collector.market_type == MarketType.FUTURES
+
+
+class TestBinanceCollectorFilenames:
+    """Tests for market-type-aware filename generation."""
+
+    def test_spot_filename_prefix(self) -> None:
+        """Spot files have 'binance_spot_' prefix."""
+        collector = BinancePublicDataCollector(
+            market_type=MarketType.SPOT,
+            symbol="BTCUSDT",
+            start_date="2024-01-01",
+            end_date="2024-01-31",
+        )
+        assert collector.market_type.filename_prefix == "binance_spot_"
+
+    def test_futures_filename_prefix(self) -> None:
+        """Futures files have 'binance_futures_' prefix."""
+        collector = BinancePublicDataCollector(
+            market_type=MarketType.FUTURES,
+            symbol="BTCUSDT",
+            start_date="2024-01-01",
+            end_date="2024-01-31",
+        )
+        assert collector.market_type.filename_prefix == "binance_futures_"

--- a/tests/test_binance_collector_market_type.py
+++ b/tests/test_binance_collector_market_type.py
@@ -1,0 +1,68 @@
+"""Tests for BinancePublicDataCollector market_type parameter.
+
+TDD tests for Task 3: Adding market_type parameter to BinancePublicDataCollector.
+"""
+
+import pytest
+
+from gapless_crypto_data.collectors.binance_public_data_collector import (
+    BinancePublicDataCollector,
+)
+from gapless_crypto_data.market_types import MarketType
+
+
+class TestBinanceCollectorMarketType:
+    """Tests for market_type parameter in BinancePublicDataCollector."""
+
+    def test_spot_base_url(self) -> None:
+        """Verify base_url contains 'data/spot/monthly/klines' for SPOT market."""
+        collector = BinancePublicDataCollector(
+            market_type=MarketType.SPOT,
+            symbol="BTCUSDT",
+            start_date="2024-01-01",
+            end_date="2024-01-31",
+        )
+
+        assert "data/spot/monthly/klines" in collector.base_url
+
+    def test_futures_base_url(self) -> None:
+        """Verify base_url contains 'data/futures/um/monthly/klines' for FUTURES market."""
+        collector = BinancePublicDataCollector(
+            market_type=MarketType.FUTURES,
+            symbol="BTCUSDT",
+            start_date="2024-01-01",
+            end_date="2024-01-31",
+        )
+
+        assert "data/futures/um/monthly/klines" in collector.base_url
+
+    def test_market_type_required(self) -> None:
+        """Verify TypeError when market_type is missing."""
+        with pytest.raises(TypeError):
+            BinancePublicDataCollector(
+                symbol="BTCUSDT",
+                start_date="2024-01-01",
+                end_date="2024-01-31",
+            )
+
+    def test_market_type_stored(self) -> None:
+        """Verify market_type is stored on instance."""
+        collector = BinancePublicDataCollector(
+            market_type=MarketType.SPOT,
+            symbol="BTCUSDT",
+            start_date="2024-01-01",
+            end_date="2024-01-31",
+        )
+
+        assert collector.market_type == MarketType.SPOT
+
+    def test_market_type_futures_stored(self) -> None:
+        """Verify FUTURES market_type is stored correctly."""
+        collector = BinancePublicDataCollector(
+            market_type=MarketType.FUTURES,
+            symbol="ETHUSDT",
+            start_date="2024-01-01",
+            end_date="2024-01-31",
+        )
+
+        assert collector.market_type == MarketType.FUTURES

--- a/tests/test_concurrent_download.py
+++ b/tests/test_concurrent_download.py
@@ -32,6 +32,7 @@ from gapless_crypto_data.collectors.hybrid_url_generator import (
     DownloadTask,
     HybridUrlGenerator,
 )
+from gapless_crypto_data.market_types import MarketType
 
 
 class TestHybridUrlGenerator:
@@ -40,13 +41,14 @@ class TestHybridUrlGenerator:
     def setup_method(self):
         """Setup test fixtures."""
         self.generator = HybridUrlGenerator(
+            market_type=MarketType.SPOT,
             daily_lookback_days=30,
             max_concurrent_per_batch=13,
         )
 
     def test_init_defaults(self):
         """Test initialization with default parameters."""
-        generator = HybridUrlGenerator()
+        generator = HybridUrlGenerator(market_type=MarketType.SPOT)
 
         assert generator.daily_lookback_days == 30
         assert generator.max_concurrent_per_batch == 13
@@ -606,7 +608,9 @@ class TestConcurrentDownloadIntegration:
     async def test_end_to_end_workflow(self):
         """Test end-to-end workflow: URL generation -> Download -> Processing."""
         # Generate URLs for small date range
-        generator = HybridUrlGenerator(daily_lookback_days=365)  # Force monthly
+        generator = HybridUrlGenerator(
+            market_type=MarketType.SPOT, daily_lookback_days=365
+        )  # Force monthly
 
         tasks = generator.generate_download_tasks(
             symbol="BTCUSDT",

--- a/tests/test_futures_integration.py
+++ b/tests/test_futures_integration.py
@@ -1,0 +1,37 @@
+"""Integration tests for futures data fetching."""
+
+import pytest
+
+from gapless_crypto_data import fetch_data
+
+
+@pytest.mark.integration
+class TestFuturesIntegration:
+    """Integration tests for USDT-M futures data."""
+
+    def test_fetch_futures_btcusdt_1d(self):
+        """Fetch 1 week of BTCUSDT futures data."""
+        df = fetch_data(
+            symbol="BTCUSDT",
+            market_type="futures",
+            timeframe="1d",
+            start="2024-01-01",
+            end="2024-01-07",
+        )
+
+        assert len(df) > 0
+        assert "close" in df.columns
+        assert "volume" in df.columns
+
+    def test_fetch_spot_btcusdt_1d(self):
+        """Fetch 1 week of BTCUSDT spot data for comparison."""
+        df = fetch_data(
+            symbol="BTCUSDT",
+            market_type="spot",
+            timeframe="1d",
+            start="2024-01-01",
+            end="2024-01-07",
+        )
+
+        assert len(df) > 0
+        assert "close" in df.columns

--- a/tests/test_gapless_validation_1d_2018_present.py
+++ b/tests/test_gapless_validation_1d_2018_present.py
@@ -20,6 +20,7 @@ import pytest
 
 from gapless_crypto_data.collectors.binance_public_data_collector import BinancePublicDataCollector
 from gapless_crypto_data.gap_filling.universal_gap_filler import UniversalGapFiller
+from gapless_crypto_data.market_types import MarketType
 
 
 class TestGaplessValidation1d2018Present:
@@ -57,7 +58,11 @@ class TestGaplessValidation1d2018Present:
 
         # Initialize collector
         collector = BinancePublicDataCollector(
-            symbol="BTCUSDT", start_date=start_date, end_date=end_date, output_dir=temp_output_dir
+            market_type=MarketType.SPOT,
+            symbol="BTCUSDT",
+            start_date=start_date,
+            end_date=end_date,
+            output_dir=temp_output_dir,
         )
 
         # Collect 1d data
@@ -97,7 +102,11 @@ class TestGaplessValidation1d2018Present:
 
         # First collect the data
         collector = BinancePublicDataCollector(
-            symbol="BTCUSDT", start_date=start_date, end_date=end_date, output_dir=temp_output_dir
+            market_type=MarketType.SPOT,
+            symbol="BTCUSDT",
+            start_date=start_date,
+            end_date=end_date,
+            output_dir=temp_output_dir,
         )
 
         result = collector.collect_timeframe_data("1d")
@@ -140,7 +149,11 @@ class TestGaplessValidation1d2018Present:
 
         # Collect data
         collector = BinancePublicDataCollector(
-            symbol="BTCUSDT", start_date=start_date, end_date=end_date, output_dir=temp_output_dir
+            market_type=MarketType.SPOT,
+            symbol="BTCUSDT",
+            start_date=start_date,
+            end_date=end_date,
+            output_dir=temp_output_dir,
         )
 
         result = collector.collect_timeframe_data("1d")
@@ -225,7 +238,11 @@ class TestGaplessValidation1d2018Present:
 
         # Collect data
         collector = BinancePublicDataCollector(
-            symbol="BTCUSDT", start_date=start_date, end_date=end_date, output_dir=temp_output_dir
+            market_type=MarketType.SPOT,
+            symbol="BTCUSDT",
+            start_date=start_date,
+            end_date=end_date,
+            output_dir=temp_output_dir,
         )
 
         result = collector.collect_timeframe_data("1d")
@@ -262,7 +279,11 @@ class TestGaplessValidation1d2018Present:
 
         # Collect data
         collector = BinancePublicDataCollector(
-            symbol="BTCUSDT", start_date=start_date, end_date=end_date, output_dir=temp_output_dir
+            market_type=MarketType.SPOT,
+            symbol="BTCUSDT",
+            start_date=start_date,
+            end_date=end_date,
+            output_dir=temp_output_dir,
         )
 
         result = collector.collect_timeframe_data("1d")

--- a/tests/test_hybrid_url_generator.py
+++ b/tests/test_hybrid_url_generator.py
@@ -1,0 +1,138 @@
+"""Tests for HybridUrlGenerator with MarketType support.
+
+Tests verify:
+- market_type parameter is required (no default)
+- base_url is computed from market_type.base_path
+- URL generation includes correct market path segments
+"""
+
+from datetime import datetime
+
+import pytest
+
+from gapless_crypto_data.collectors.hybrid_url_generator import HybridUrlGenerator
+from gapless_crypto_data.market_types import MarketType
+
+
+class TestHybridUrlGeneratorBaseUrl:
+    """Test base_url computation from market_type."""
+
+    def test_spot_base_url(self):
+        """Test SPOT market_type produces correct base_url."""
+        generator = HybridUrlGenerator(market_type=MarketType.SPOT)
+        assert generator.base_url == "https://data.binance.vision/data/spot"
+
+    def test_futures_base_url(self):
+        """Test FUTURES market_type produces correct base_url."""
+        generator = HybridUrlGenerator(market_type=MarketType.FUTURES)
+        assert generator.base_url == "https://data.binance.vision/data/futures/um"
+
+    def test_market_type_stored(self):
+        """Test market_type is stored on the instance."""
+        generator = HybridUrlGenerator(market_type=MarketType.SPOT)
+        assert generator.market_type == MarketType.SPOT
+
+        generator_futures = HybridUrlGenerator(market_type=MarketType.FUTURES)
+        assert generator_futures.market_type == MarketType.FUTURES
+
+
+class TestHybridUrlGeneratorMarketTypeRequired:
+    """Test that market_type parameter is required."""
+
+    def test_market_type_required(self):
+        """Test TypeError when market_type is missing."""
+        with pytest.raises(TypeError) as exc_info:
+            HybridUrlGenerator()  # type: ignore[call-arg]
+        assert "market_type" in str(exc_info.value)
+
+
+class TestHybridUrlGeneratorUrlGeneration:
+    """Test URL generation for different market types."""
+
+    def test_spot_monthly_url_generation(self):
+        """Test monthly URLs contain '/spot/monthly/klines/'."""
+        generator = HybridUrlGenerator(
+            market_type=MarketType.SPOT,
+            daily_lookback_days=0,  # Force all to monthly
+        )
+        tasks = generator.generate_download_tasks(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 31),
+        )
+
+        assert len(tasks) > 0
+        for task in tasks:
+            assert "/spot/monthly/klines/" in task.url
+
+    def test_futures_monthly_url_generation(self):
+        """Test monthly URLs contain '/futures/um/monthly/klines/'."""
+        generator = HybridUrlGenerator(
+            market_type=MarketType.FUTURES,
+            daily_lookback_days=0,  # Force all to monthly
+        )
+        tasks = generator.generate_download_tasks(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 31),
+        )
+
+        assert len(tasks) > 0
+        for task in tasks:
+            assert "/futures/um/monthly/klines/" in task.url
+
+    def test_spot_daily_url_generation(self):
+        """Test daily URLs contain '/spot/daily/klines/'."""
+        generator = HybridUrlGenerator(
+            market_type=MarketType.SPOT,
+            daily_lookback_days=365 * 10,  # Force all to daily
+        )
+        tasks = generator.generate_download_tasks(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 3),
+        )
+
+        assert len(tasks) > 0
+        for task in tasks:
+            assert "/spot/daily/klines/" in task.url
+
+    def test_futures_daily_url_generation(self):
+        """Test daily URLs contain '/futures/um/daily/klines/'."""
+        generator = HybridUrlGenerator(
+            market_type=MarketType.FUTURES,
+            daily_lookback_days=365 * 10,  # Force all to daily
+        )
+        tasks = generator.generate_download_tasks(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 3),
+        )
+
+        assert len(tasks) > 0
+        for task in tasks:
+            assert "/futures/um/daily/klines/" in task.url
+
+
+class TestHybridUrlGeneratorOptionalParams:
+    """Test optional parameters still work with market_type."""
+
+    def test_daily_lookback_days_param(self):
+        """Test daily_lookback_days parameter is accepted."""
+        generator = HybridUrlGenerator(
+            market_type=MarketType.SPOT,
+            daily_lookback_days=45,
+        )
+        assert generator.daily_lookback_days == 45
+
+    def test_max_concurrent_per_batch_param(self):
+        """Test max_concurrent_per_batch parameter is accepted."""
+        generator = HybridUrlGenerator(
+            market_type=MarketType.SPOT,
+            max_concurrent_per_batch=10,
+        )
+        assert generator.max_concurrent_per_batch == 10

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,6 +9,7 @@ import pytest
 
 from gapless_crypto_data.collectors.binance_public_data_collector import BinancePublicDataCollector
 from gapless_crypto_data.gap_filling.universal_gap_filler import UniversalGapFiller
+from gapless_crypto_data.market_types import MarketType
 from gapless_crypto_data.validation import CSVValidator
 
 
@@ -28,7 +29,11 @@ class TestEndToEndIntegration:
             end_date = "2024-01-02"  # Just 2 days for testing
 
             collector = BinancePublicDataCollector(
-                symbol="BTCUSDT", start_date=start_date, end_date=end_date, output_dir=output_dir
+                market_type=MarketType.SPOT,
+                symbol="BTCUSDT",
+                start_date=start_date,
+                end_date=end_date,
+                output_dir=output_dir,
             )
 
             try:
@@ -138,6 +143,7 @@ class TestEndToEndIntegration:
 
             # Test 1: Invalid symbol handling
             collector = BinancePublicDataCollector(
+                market_type=MarketType.SPOT,
                 symbol="INVALIDSYMBOL",
                 start_date="2024-01-01",
                 end_date="2024-01-02",
@@ -156,6 +162,7 @@ class TestEndToEndIntegration:
 
             # Test 2: Invalid timeframe handling
             collector = BinancePublicDataCollector(
+                market_type=MarketType.SPOT,
                 symbol="BTCUSDT",
                 start_date="2024-01-01",
                 end_date="2024-01-02",

--- a/tests/test_market_types.py
+++ b/tests/test_market_types.py
@@ -1,0 +1,79 @@
+"""Tests for MarketType enum.
+
+Tests verify:
+- Enum values (SPOT, FUTURES)
+- base_path property for both market types
+- filename_prefix property for both market types
+- String conversion (MarketType("spot") == MarketType.SPOT)
+- Invalid value raises ValueError
+"""
+
+import pytest
+
+from gapless_crypto_data.market_types import MarketType
+
+
+class TestMarketTypeEnum:
+    """Test MarketType enum values and string conversion."""
+
+    def test_spot_value(self):
+        """Test SPOT enum has correct string value."""
+        assert MarketType.SPOT.value == "spot"
+
+    def test_futures_value(self):
+        """Test FUTURES enum has correct string value."""
+        assert MarketType.FUTURES.value == "futures"
+
+    def test_string_conversion_spot(self):
+        """Test MarketType("spot") returns MarketType.SPOT."""
+        assert MarketType("spot") == MarketType.SPOT
+
+    def test_string_conversion_futures(self):
+        """Test MarketType("futures") returns MarketType.FUTURES."""
+        assert MarketType("futures") == MarketType.FUTURES
+
+    def test_invalid_value_raises_error(self):
+        """Test invalid market type raises ValueError."""
+        with pytest.raises(ValueError):
+            MarketType("invalid")
+
+    def test_invalid_value_perpetual_raises_error(self):
+        """Test 'perpetual' market type raises ValueError."""
+        with pytest.raises(ValueError):
+            MarketType("perpetual")
+
+
+class TestMarketTypeBasePath:
+    """Test base_path property for URL generation."""
+
+    def test_spot_base_path(self):
+        """Test SPOT base_path returns 'spot'."""
+        assert MarketType.SPOT.base_path == "spot"
+
+    def test_futures_base_path(self):
+        """Test FUTURES base_path returns 'futures/um'."""
+        assert MarketType.FUTURES.base_path == "futures/um"
+
+
+class TestMarketTypeFilenamePrefix:
+    """Test filename_prefix property for output files."""
+
+    def test_spot_filename_prefix(self):
+        """Test SPOT filename_prefix returns 'binance_spot_'."""
+        assert MarketType.SPOT.filename_prefix == "binance_spot_"
+
+    def test_futures_filename_prefix(self):
+        """Test FUTURES filename_prefix returns 'binance_futures_'."""
+        assert MarketType.FUTURES.filename_prefix == "binance_futures_"
+
+
+class TestMarketTypeStringRepresentation:
+    """Test string representation of MarketType enum."""
+
+    def test_spot_str(self):
+        """Test str(MarketType.SPOT) returns 'spot'."""
+        assert str(MarketType.SPOT) == "spot"
+
+    def test_futures_str(self):
+        """Test str(MarketType.FUTURES) returns 'futures'."""
+        assert str(MarketType.FUTURES) == "futures"

--- a/tests/test_monthly_to_daily_fallback.py
+++ b/tests/test_monthly_to_daily_fallback.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 import pytest
 
 from gapless_crypto_data.collectors.binance_public_data_collector import BinancePublicDataCollector
+from gapless_crypto_data.market_types import MarketType
 
 
 class TestMonthlyToDailyFallback:
@@ -19,7 +20,7 @@ class TestMonthlyToDailyFallback:
 
     def test_fallback_url_generation(self):
         """Test generation of daily URLs for fallback."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
 
         # Test generating daily URLs for September 2025 (30 days)
         daily_urls = collector._generate_daily_urls_for_month("BTCUSDT", "1d", "2025", "09")
@@ -41,7 +42,7 @@ class TestMonthlyToDailyFallback:
 
     def test_fallback_filename_parsing(self):
         """Test parsing of failed monthly filename."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
 
         # Test with mock fallback method to avoid actual downloads
         with (
@@ -65,6 +66,7 @@ class TestMonthlyToDailyFallback:
         # Use a temporary output directory
         with tempfile.TemporaryDirectory() as temp_dir:
             collector = BinancePublicDataCollector(
+                market_type=MarketType.SPOT,
                 symbol="BTCUSDT",
                 start_date="2025-09-01",
                 end_date="2025-09-02",  # Just test a few days
@@ -88,7 +90,7 @@ class TestMonthlyToDailyFallback:
 
     def test_fallback_logging_and_output(self, capfd):
         """Test that fallback mechanism provides proper logging."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
 
         # Mock the daily URL generation and downloads
         with (
@@ -124,7 +126,7 @@ class TestMonthlyToDailyFallback:
 
     def test_invalid_filename_handling(self):
         """Test handling of invalid monthly filename formats."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
 
         # Test with invalid filename
         result = collector._fallback_to_daily_files("invalid-filename.zip")
@@ -134,7 +136,7 @@ class TestMonthlyToDailyFallback:
 
     def test_february_leap_year_handling(self):
         """Test daily URL generation for February in leap year."""
-        collector = BinancePublicDataCollector()
+        collector = BinancePublicDataCollector(market_type=MarketType.SPOT)
 
         # Test February 2024 (leap year - 29 days)
         daily_urls_leap = collector._generate_daily_urls_for_month("BTCUSDT", "1h", "2024", "02")
@@ -157,6 +159,7 @@ class TestMonthlyToDailyFallback:
         with tempfile.TemporaryDirectory() as temp_dir:
             # Test a range that includes recent months (likely to trigger fallback)
             collector = BinancePublicDataCollector(
+                market_type=MarketType.SPOT,
                 symbol="BTCUSDT",
                 start_date="2025-08-25",  # End of August
                 end_date="2025-09-05",  # Beginning of September (should trigger fallback)

--- a/tests/test_output_dir_dataframe_fix.py
+++ b/tests/test_output_dir_dataframe_fix.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pandas as pd
 
 from gapless_crypto_data import BinancePublicDataCollector
+from gapless_crypto_data.market_types import MarketType
 
 
 def test_output_dir_bug_fix():
@@ -15,6 +16,7 @@ def test_output_dir_bug_fix():
         test_output_dir.mkdir(parents=True, exist_ok=True)
 
         collector = BinancePublicDataCollector(
+            market_type=MarketType.SPOT,
             symbol="BTCUSDT",
             start_date="2024-01-01",
             end_date="2024-01-01",
@@ -49,6 +51,7 @@ def test_dataframe_return_functionality():
         test_output_dir.mkdir(parents=True, exist_ok=True)
 
         collector = BinancePublicDataCollector(
+            market_type=MarketType.SPOT,
             symbol="BTCUSDT",
             start_date="2024-01-01",
             end_date="2024-01-01",
@@ -118,6 +121,7 @@ def test_backwards_compatibility():
         test_output_dir.mkdir(parents=True, exist_ok=True)
 
         collector = BinancePublicDataCollector(
+            market_type=MarketType.SPOT,
             symbol="BTCUSDT",
             start_date="2024-01-01",
             end_date="2024-01-01",

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from gapless_crypto_data.market_types import MarketType
+
 
 def test_package_import():
     """Test that the main package can be imported."""
@@ -127,7 +129,10 @@ def test_all_imports_valid():
 
         # Test instantiation with safe defaults
         collector = BinancePublicDataCollector(
-            symbol="BTCUSDT", start_date="2022-01-01", end_date="2022-01-02"
+            market_type=MarketType.SPOT,
+            symbol="BTCUSDT",
+            start_date="2022-01-01",
+            end_date="2022-01-02",
         )
         gap_filler = UniversalGapFiller()
 

--- a/tests/test_simple_api.py
+++ b/tests/test_simple_api.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pytest
 
 import gapless_crypto_data as gcd
+from gapless_crypto_data.market_types import MarketType
 
 
 class TestSimpleAPI:
@@ -30,19 +31,13 @@ class TestSimpleAPI:
         assert hasattr(gcd, "UniversalGapFiller")
 
     def test_get_supported_symbols(self):
-        """Test getting supported trading symbols"""
-        symbols = gcd.get_supported_symbols()
+        """Test getting supported trading symbols (deprecated)"""
+        # Function is deprecated and returns empty list
+        with pytest.warns(DeprecationWarning, match="get_supported_symbols.*deprecated"):
+            symbols = gcd.get_supported_symbols()
 
         assert isinstance(symbols, list)
-        assert len(symbols) > 0
-        assert "BTCUSDT" in symbols
-        assert "ETHUSDT" in symbols
-        assert "SOLUSDT" in symbols
-
-        # All symbols should be strings and end with USDT
-        for symbol in symbols:
-            assert isinstance(symbol, str)
-            assert symbol.endswith("USDT")
+        assert len(symbols) == 0  # Deprecated - returns empty list
 
     def test_get_supported_timeframes(self):
         """Test getting supported timeframe intervals"""
@@ -87,7 +82,7 @@ class TestSimpleAPI:
         """Test fetch_data function parameter handling"""
         # Test with minimal parameters (should not raise)
         try:
-            df = gcd.fetch_data("BTCUSDT", "1h", limit=1)
+            df = gcd.fetch_data("BTCUSDT", "spot", timeframe="1h", limit=1)
             # Should return DataFrame even if empty
             assert isinstance(df, pd.DataFrame)
             # With default datetime index, should have DatetimeIndex (if data available)
@@ -101,20 +96,24 @@ class TestSimpleAPI:
         """Test fetch_data function with different index_type parameters"""
         try:
             # Test datetime index (default)
-            df_datetime = gcd.fetch_data("BTCUSDT", "1h", limit=1, index_type="datetime")
+            df_datetime = gcd.fetch_data(
+                "BTCUSDT", "spot", timeframe="1h", limit=1, index_type="datetime"
+            )
             assert isinstance(df_datetime, pd.DataFrame)
             if not df_datetime.empty:
                 assert isinstance(df_datetime.index, pd.DatetimeIndex)
 
             # Test range index (legacy)
-            df_range = gcd.fetch_data("BTCUSDT", "1h", limit=1, index_type="range")
+            df_range = gcd.fetch_data(
+                "BTCUSDT", "spot", timeframe="1h", limit=1, index_type="range"
+            )
             assert isinstance(df_range, pd.DataFrame)
             if not df_range.empty:
                 assert isinstance(df_range.index, pd.RangeIndex)
                 assert "date" in df_range.columns
 
             # Test auto index (same as datetime)
-            df_auto = gcd.fetch_data("BTCUSDT", "1h", limit=1, index_type="auto")
+            df_auto = gcd.fetch_data("BTCUSDT", "spot", timeframe="1h", limit=1, index_type="auto")
             assert isinstance(df_auto, pd.DataFrame)
             if not df_auto.empty:
                 assert isinstance(df_auto.index, pd.DatetimeIndex)
@@ -126,13 +125,13 @@ class TestSimpleAPI:
     def test_fetch_data_invalid_index_type(self):
         """Test fetch_data function with invalid index_type parameter"""
         with pytest.raises(ValueError, match="Invalid index_type"):
-            gcd.fetch_data("BTCUSDT", "1h", limit=1, index_type="invalid")
+            gcd.fetch_data("BTCUSDT", "spot", timeframe="1h", limit=1, index_type="invalid")
 
     def test_fetch_data_default_behavior(self):
         """Test that fetch_data defaults to datetime index for better UX"""
         try:
             # Default behavior should be datetime index
-            df = gcd.fetch_data("BTCUSDT", "1h", start="2024-01-01", end="2024-01-02")
+            df = gcd.fetch_data("BTCUSDT", "spot", timeframe="1h", start="2024-01-01", end="2024-01-02")
             assert isinstance(df, pd.DataFrame)
             if not df.empty:
                 assert isinstance(df.index, pd.DatetimeIndex)
@@ -152,7 +151,7 @@ class TestSimpleAPI:
         try:
             # Explicit range index should work like before
             df = gcd.fetch_data(
-                "BTCUSDT", "1h", start="2024-01-01", end="2024-01-02", index_type="range"
+                "BTCUSDT", "spot", timeframe="1h", start="2024-01-01", end="2024-01-02", index_type="range"
             )
             assert isinstance(df, pd.DataFrame)
             if not df.empty:
@@ -170,8 +169,8 @@ class TestSimpleAPI:
         """Test that download is an alias for fetch_data"""
         # Should not raise errors for basic parameter validation
         try:
-            df1 = gcd.fetch_data("BTCUSDT", "1h", start="2024-01-01", end="2024-01-02")
-            df2 = gcd.download("BTCUSDT", "1h", start="2024-01-01", end="2024-01-02")
+            df1 = gcd.fetch_data("BTCUSDT", "spot", timeframe="1h", start="2024-01-01", end="2024-01-02")
+            df2 = gcd.download("BTCUSDT", "spot", timeframe="1h", start="2024-01-01", end="2024-01-02")
 
             # Both should return DataFrames with same structure
             assert isinstance(df1, pd.DataFrame)
@@ -187,7 +186,7 @@ class TestSimpleAPI:
         try:
             # Test datetime index (default)
             df_datetime = gcd.download(
-                "BTCUSDT", "1h", start="2024-01-01", end="2024-01-02", index_type="datetime"
+                "BTCUSDT", "spot", timeframe="1h", start="2024-01-01", end="2024-01-02", index_type="datetime"
             )
             assert isinstance(df_datetime, pd.DataFrame)
             if not df_datetime.empty:
@@ -195,7 +194,7 @@ class TestSimpleAPI:
 
             # Test range index
             df_range = gcd.download(
-                "BTCUSDT", "1h", start="2024-01-01", end="2024-01-02", index_type="range"
+                "BTCUSDT", "spot", timeframe="1h", start="2024-01-01", end="2024-01-02", index_type="range"
             )
             assert isinstance(df_range, pd.DataFrame)
             if not df_range.empty:
@@ -209,7 +208,7 @@ class TestSimpleAPI:
         """Test that returned DataFrames have expected microstructure columns"""
         try:
             # Test with datetime index (default) - 'date' column still present
-            df_datetime = gcd.fetch_data("BTCUSDT", "1d", start="2024-01-01", end="2024-01-02")
+            df_datetime = gcd.fetch_data("BTCUSDT", "spot", timeframe="1d", start="2024-01-01", end="2024-01-02")
 
             if not df_datetime.empty:
                 # Expected columns when using datetime index (includes 'date' column for compatibility)
@@ -238,7 +237,7 @@ class TestSimpleAPI:
 
             # Test with range index (legacy) - same columns but RangeIndex
             df_range = gcd.fetch_data(
-                "BTCUSDT", "1d", start="2024-01-01", end="2024-01-02", index_type="range"
+                "BTCUSDT", "spot", timeframe="1d", start="2024-01-01", end="2024-01-02", index_type="range"
             )
 
             if not df_range.empty:
@@ -285,7 +284,7 @@ class TestSimpleAPI:
     def test_backward_compatibility(self):
         """Test that class-based API still works (backward compatibility)"""
         # Should be able to import and instantiate classes
-        collector = gcd.BinancePublicDataCollector()
+        collector = gcd.BinancePublicDataCollector(market_type=MarketType.SPOT)
         gap_filler = gcd.UniversalGapFiller()
 
         assert collector is not None
@@ -306,12 +305,12 @@ class TestSimpleAPI:
         try:
             # Function-based API with range index for consistency comparison
             df_function = gcd.fetch_data(
-                symbol, timeframe, start=start, end=end, index_type="range"
+                symbol, "spot", timeframe=timeframe, start=start, end=end, index_type="range"
             )
 
             # Class-based API
             collector = gcd.BinancePublicDataCollector(
-                symbol=symbol, start_date=start, end_date=end
+                market_type=MarketType.SPOT, symbol=symbol, start_date=start, end_date=end
             )
             result_class = collector.collect_timeframe_data(timeframe)
 
@@ -324,7 +323,7 @@ class TestSimpleAPI:
                 assert list(df_function.columns) == list(df_class.columns)
 
                 # Test that new default datetime index also works
-                df_function_datetime = gcd.fetch_data(symbol, timeframe, start=start, end=end)
+                df_function_datetime = gcd.fetch_data(symbol, "spot", timeframe=timeframe, start=start, end=end)
                 assert isinstance(df_function_datetime, pd.DataFrame)
                 if not df_function_datetime.empty:
                     assert isinstance(df_function_datetime.index, pd.DatetimeIndex)
@@ -343,7 +342,7 @@ class TestAPIUsagePatterns:
         """Test intuitive download usage pattern"""
         try:
             # Common download pattern with date range
-            df = gcd.download("BTCUSDT", "1d", start="2024-01-01", end="2024-01-02")
+            df = gcd.download("BTCUSDT", "spot", timeframe="1d", start="2024-01-01", end="2024-01-02")
             assert isinstance(df, pd.DataFrame)
 
         except Exception as e:
@@ -351,19 +350,17 @@ class TestAPIUsagePatterns:
 
     def test_symbol_discovery_pattern(self):
         """Test symbol and timeframe discovery pattern"""
-        # Pattern for discovering available options
-        symbols = gcd.get_supported_symbols()
+        # get_supported_symbols() is deprecated - use any valid Binance symbol
         timeframes = gcd.get_supported_timeframes()
 
-        assert len(symbols) > 0
         assert len(timeframes) > 0
 
-        # Should be able to use discovered values
-        symbol = symbols[0]  # First available symbol
-        timeframe = timeframes[0] if "1d" not in timeframes else "1d"
+        # Use known valid symbol and discovered timeframe
+        symbol = "BTCUSDT"  # Use known valid symbol
+        timeframe = "1d" if "1d" in timeframes else timeframes[0]
 
         try:
-            df = gcd.fetch_data(symbol, timeframe, limit=1)
+            df = gcd.fetch_data(symbol, "spot", timeframe=timeframe, limit=1)
             assert isinstance(df, pd.DataFrame)
 
         except Exception as e:
@@ -375,6 +372,7 @@ class TestAPIUsagePatterns:
             # Test with default datetime index
             df = gcd.fetch_data(
                 symbol="ETHUSDT",
+                market_type="spot",
                 timeframe="1h",
                 start="2024-01-01",
                 end="2024-01-01",  # Single day
@@ -390,6 +388,7 @@ class TestAPIUsagePatterns:
             # Test with legacy range index
             df_range = gcd.fetch_data(
                 symbol="ETHUSDT",
+                market_type="spot",
                 timeframe="1h",
                 start="2024-01-01",
                 end="2024-01-01",
@@ -409,7 +408,7 @@ class TestAPIUsagePatterns:
         try:
             # download() should have auto_fill_gaps=True by default
             df = gcd.download(
-                "BTCUSDT", "5m", start="2023-03-23", end="2023-03-25", auto_fill_gaps=True
+                "BTCUSDT", "spot", timeframe="5m", start="2023-03-23", end="2023-03-25", auto_fill_gaps=True
             )
 
             assert isinstance(df, pd.DataFrame)
@@ -422,7 +421,7 @@ class TestAPIUsagePatterns:
         try:
             # Should accept auto_fill_gaps=False to get raw Vision data
             df = gcd.download(
-                "BTCUSDT", "1h", start="2024-01-01", end="2024-01-02", auto_fill_gaps=False
+                "BTCUSDT", "spot", timeframe="1h", start="2024-01-01", end="2024-01-02", auto_fill_gaps=False
             )
 
             assert isinstance(df, pd.DataFrame)
@@ -434,9 +433,9 @@ class TestAPIUsagePatterns:
         """Test that fetch_data also supports auto_fill_gaps parameter"""
         try:
             # fetch_data() should also have auto_fill_gaps parameter
-            df_with_fill = gcd.fetch_data("ETHUSDT", "1h", limit=48, auto_fill_gaps=True)
+            df_with_fill = gcd.fetch_data("ETHUSDT", "spot", timeframe="1h", limit=48, auto_fill_gaps=True)
 
-            df_without_fill = gcd.fetch_data("ETHUSDT", "1h", limit=48, auto_fill_gaps=False)
+            df_without_fill = gcd.fetch_data("ETHUSDT", "spot", timeframe="1h", limit=48, auto_fill_gaps=False)
 
             assert isinstance(df_with_fill, pd.DataFrame)
             assert isinstance(df_without_fill, pd.DataFrame)
@@ -450,6 +449,7 @@ class TestAPIUsagePatterns:
             # Use period with known Binance Vision gap (March 24, 2023)
             df = gcd.download(
                 "BTCUSDT",
+                "spot",
                 timeframe="5m",
                 start="2023-03-23",
                 end="2023-03-25",


### PR DESCRIPTION
## Summary

This PR adds USDT-M Futures support to gapless-crypto-data by introducing a `MarketType` enum and making `market_type` a required parameter across the API.

### Breaking Changes (v6.0.0)

- `market_type` is now **required** for `fetch_data()`, `download()`, and `BinancePublicDataCollector`
- `get_supported_symbols()` is **deprecated** (symbol validation removed, any Binance symbol works)
- Filenames now include market type: `binance_{market_type}_SYMBOL-timeframe_...`

### New Features

- **MarketType enum** with `SPOT` and `FUTURES` values
- Support for Binance Vision Futures data at `https://data.binance.vision/data/futures/um/`
- Both daily and monthly Futures data resolution

### API Changes

```python
# Before (v5.x)
df = gcd.fetch_data("BTCUSDT", timeframe="1h", limit=100)

# After (v6.0)
df = gcd.fetch_data("BTCUSDT", "spot", timeframe="1h", limit=100)      # Spot
df = gcd.fetch_data("BTCUSDT", "futures", timeframe="1h", limit=100)   # Futures
```

### Changes

- Add `MarketType` enum with spot/futures support
- Add `market_type` parameter to `HybridUrlGenerator`
- Add `market_type` parameter to `BinancePublicDataCollector`
- Update `fetch_data()` with required `market_type` parameter
- Update `download()` with required `market_type` parameter
- Export `MarketType` from package
- Deprecate `get_supported_symbols()` with warning
- Update `get_supported_timeframes()` to return hardcoded list
- Add comprehensive tests for all changes
- Bump version to 6.0.0

### Test Results

- 340 passed, 5 skipped, 18 warnings
- All existing functionality preserved
- New futures tests added

## Test plan

- [x] Unit tests for MarketType enum
- [x] Unit tests for HybridUrlGenerator with market_type
- [x] Unit tests for BinancePublicDataCollector with market_type
- [x] API tests for fetch_data and download
- [x] Integration tests for futures data collection
- [x] All existing tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)